### PR TITLE
Add "Recurrent Training" training lesson to the tickets system

### DIFF
--- a/app/TrainingTicket.php
+++ b/app/TrainingTicket.php
@@ -229,6 +229,8 @@ class TrainingTicket extends Model
             $position = 'Atlanta Center Introduction';
         } elseif($pos == 121) {
             $position = 'Atlanta Center';
+        } elseif($pos == 122) {
+            $position = 'Recurrent Training';
         }
 
         return $position;

--- a/resources/views/dashboard/training/edit_ticket.blade.php
+++ b/resources/views/dashboard/training/edit_ticket.blade.php
@@ -48,6 +48,7 @@ Edit Training Ticket
                         119 => 'A80 Arrival Radar',
                         120 => 'Atlanta Center Introduction',
                         121 => 'Atlanta Center',
+                        122 => 'Recurrent Training',
                     ], $ticket->position, ['placeholder' => 'Select Position', 'class' => 'form-control']) !!}
                 </div>
             </div>

--- a/resources/views/dashboard/training/new_ticket.blade.php
+++ b/resources/views/dashboard/training/new_ticket.blade.php
@@ -52,6 +52,7 @@ New Training Ticket
                         119 => 'A80 Arrival Radar',
                         120 => 'Atlanta Center Introduction',
                         121 => 'Atlanta Center',
+                        122 => 'Recurrent Training',
                     ], null, ['placeholder' => 'Select Training Session', 'class' => 'form-control']) !!}
                 </div>
             </div>

--- a/resources/views/dashboard/training/tickets.blade.php
+++ b/resources/views/dashboard/training/tickets.blade.php
@@ -293,6 +293,18 @@ Training Tickets
                             <td>{{ $t->end_time }}z</td>
                             <td data-toggle="tooltip" title="{{ $t->ins_comments }}">{{ str_limit($t->ins_comments, 40, '...') }}</td>
                         </tr>
+                    
+                    @elseif($t->position > 121)
+                    <tr>
+                        <td><a href="/dashboard/training/tickets/view/{{ $t->id }}">{{ $t->date }}</a></td>
+                        <td>{{ $t->trainer_name }}</td>
+                        <td>{{ $t->position_name }}</td>
+                        <td>{{ $t->type_name }}</td>
+                        <td>{{ $t->start_time }}z</td>
+                        <td>{{ $t->end_time }}z</td>
+                        <td data-toggle="tooltip" title="{{ $t->ins_comments }}">{{ str_limit($t->ins_comments, 40, '...') }}</td>
+
+                    </tr>
 
                     @endif
                     @endforeach


### PR DESCRIPTION
Added another ticket option for mentors titled **"Recurrent Training"**. Will display in the **"Other"** tab when viewing a controller's tickets.  