### PR TITLE
Update AdminDash.php

### DIFF
--- a/app/Http/Controllers/AdminDash.php
+++ b/app/Http/Controllers/AdminDash.php
@@ -833,7 +833,7 @@ class AdminDash extends Controller
             
              Mail::send('emails.remove_visitor', ['user' => $user], function($message) use ($user){
                         $message->from('datm@ztlartcc.org', 'vZTL ARTCC Staff')->subject('Notification of ZTL Roster Removal');
-                        $message->to($user->email);
+                        $message->to($user->email)->cc('datm@ztlartcc.org');
              });
 
             return redirect('/dashboard/controllers/roster')->with('success', 'The visitor has been removed successfully.');


### PR DESCRIPTION
now copies the `remove_visitor` email to the DATM when visitor is removed from the roster.