### PR TITLE
Fixes missing solo cert menu option

### DIFF
--- a/resources/views/dashboard/admin/roster/edit.blade.php
+++ b/resources/views/dashboard/admin/roster/edit.blade.php
@@ -170,6 +170,7 @@ Update Controller
                         {!! Form::label('ctr', 'Center Certification') !!}
                         {!! Form::select('ctr', [
                             0 => 'None',
+                            99 => 'Solo Certification',
                             1 => 'Certified'
                         ], $user->ctr, ['class' => 'form-control']) !!}
                     </div>


### PR DESCRIPTION
This PR will:
* Adds an option for non-staff member instructor/mentors to add a solo cert on the roster edit page for a user
* Close #198 