### PR TITLE
Allow INS/MTR to remove twr solo cert

### DIFF
--- a/app/Http/Controllers/AdminDash.php
+++ b/app/Http/Controllers/AdminDash.php
@@ -255,7 +255,7 @@ class AdminDash extends Controller {
                     }
                     $user->twr = $request->input('twr');
                 } else {
-                    $user->twr = 99;
+                    $user->twr = 0;
                 }
             } elseif ($request->input('twr') == 99) {
                 $expire = Carbon::now()->addMonth()->format('Y-m-d');


### PR DESCRIPTION
This PR will:
* Adds functionality requested by TA in Discord
* Allows an instructor or mentor to remove a member's solo certification
* Change from present system that required the solo cert to auto-expire after 30-days
* Close #205 