### PR TITLE
NOISS Update setup-node in build workflow to v3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
         uses: php-actions/composer@v6
 
       - name: Setup node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 18.2.0
 


### PR DESCRIPTION
This PR will:
* Update the build/validate workflow to use `setup-node` to `v3` to align with the build/build workflow