### PR TITLE
NOISS Fix realops pilot ID assignment

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -177,6 +177,7 @@ class LoginController extends Controller {
 
         if (! $realops_pilot) {
             $realops_pilot = new RealopsPilot;
+            $realops_pilot->id = $cid;
         }
 
         $realops_pilot->fname = $fname;


### PR DESCRIPTION
This PR will:
* Fix the issue of the realops pilot ID not being set correctly including...
  * Inadvertent ability to book multiple flights
  * Inability to cancel flights

This should be tested with multiple people prior to merging to ensure that the issue is corrected, and merging should be held until the current realops databases can be dumped as this will break the current implementation.