### PR TITLE
#273 Fix filename upload bug

### DIFF
--- a/app/Http/Controllers/AdminDash.php
+++ b/app/Http/Controllers/AdminDash.php
@@ -797,7 +797,7 @@ class AdminDash extends Controller {
         $time = Carbon::now()->timestamp;
 
         $ext = $request->file('file')->getClientOriginalExtension();
-        $name = $request->title.'_'.$time.'.'.$ext;
+        $name = preg_replace('/^[\w\-. ]+$/','',$request->title).'_'.$time.'.'.$ext;
 
         $path = $request->file('file')->storeAs(
             '/public/files',

--- a/app/Http/Controllers/AdminDash.php
+++ b/app/Http/Controllers/AdminDash.php
@@ -797,7 +797,7 @@ class AdminDash extends Controller {
         $time = Carbon::now()->timestamp;
 
         $ext = $request->file('file')->getClientOriginalExtension();
-        $name = preg_replace('/^[\w\-. ]+$/','',$request->title).'_'.$time.'.'.$ext;
+        $name = preg_replace('/^[\w\-. ]+$/', '', $request->title).'_'.$time.'.'.$ext;
 
         $path = $request->file('file')->storeAs(
             '/public/files',


### PR DESCRIPTION
This PR will:
* Makes file titles safe as file names by removing special characters before storing the file
* Close #273 
