### PR TITLE
#243 Adds logic to create a safe error message

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -47,7 +47,7 @@ class Handler extends ExceptionHandler {
         if ($exception->getStatusCode() == 500) {
             return $this->safeErrorMessage($exception);
         }
-        return parent::render($request, $modifiedException);
+        return parent::render($request, $exception);
     }
 
     /**

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -44,24 +44,6 @@ class Handler extends ExceptionHandler {
      * @return \Illuminate\Http\Response
      */
     public function render($request, Throwable $exception) {
-        if ($exception->getStatusCode() == 500) {
-            return $this->safeErrorMessage($exception);
-        }
         return parent::render($request, $exception);
-    }
-
-    /**
-     * Checks exception messages for POST/GET variables and removes them. Prevents dangerous things like environment variables
-     * from leaking while ensuring a meaningful and safe message can be displayed to the user (and reported to the dev team).
-     */
-    protected function safeErrorMessage($exception) {
-        $safeErrorMessage = 'Unspecified error';
-        $exceptionMessage = $exception->getMessage();
-        if (preg_match('/(https?:\/\/.*[\?\&])/', $exceptionMessage)) {
-            $safeErrorMessage = preg_replace('/(https?:\/\/.*[\?\&][^\s]+)/', '---', $exceptionMessage);
-        } else {
-            $safeErrorMessage = $exceptionMessage;
-        }
-        return view()->make('errors.500')->with('safeErrorMessage', $safeErrorMessage);
     }
 }

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -44,15 +44,17 @@ class Handler extends ExceptionHandler {
      * @return \Illuminate\Http\Response
      */
     public function render($request, Throwable $exception) {
-        $safeErrorMessage = $this->safeErrorMessage($exception);
-        return parent::render($request, $exception, $safeErrorMessage);
+        if($exception->getStatusCode() == 500) {
+            return $this->safeErrorMessage($exception);
+        }
+        return parent::render($request, $modifiedException);
     }
 
     /**
      * Checks exception messages for POST/GET variables and removes them. Prevents dangerous things like environment variables
      * from leaking while ensuring a meaningful and safe message can be displayed to the user (and reported to the dev team).
      */
-    protected function safeErrorMessage($exception): string {
+    protected function safeErrorMessage($exception) {
         $safeErrorMessage = 'Unspecified error';
         $exceptionMessage = $exception->getMessage();
         if (preg_match('/(https?:\/\/.*[\?\&])/', $exceptionMessage)) {
@@ -60,6 +62,6 @@ class Handler extends ExceptionHandler {
         } else {
             $safeErrorMessage = $exceptionMessage;
         }
-        return $safeErrorMessage;
+        return view()->make('errors.500')->with('safeErrorMessage', $safeErrorMessage);
     }
 }

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -55,10 +55,9 @@ class Handler extends ExceptionHandler {
     protected function safeErrorMessage($exception): string {
         $safeErrorMessage = 'Unspecified error';
         $exceptionMessage = $exception->getMessage();
-        if(preg_match('/(https?:\/\/.*[\?\&])/', $exceptionMessage)) {
+        if (preg_match('/(https?:\/\/.*[\?\&])/', $exceptionMessage)) {
             $safeErrorMessage = preg_replace('/(https?:\/\/.*[\?\&][^\s]+)/', '---', $exceptionMessage);
-        }
-        else {
+        } else {
             $safeErrorMessage = $exceptionMessage;
         }
         return $safeErrorMessage;

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -44,7 +44,7 @@ class Handler extends ExceptionHandler {
      * @return \Illuminate\Http\Response
      */
     public function render($request, Throwable $exception) {
-        if($exception->getStatusCode() == 500) {
+        if ($exception->getStatusCode() == 500) {
             return $this->safeErrorMessage($exception);
         }
         return parent::render($request, $modifiedException);

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -44,6 +44,23 @@ class Handler extends ExceptionHandler {
      * @return \Illuminate\Http\Response
      */
     public function render($request, Throwable $exception) {
-        return parent::render($request, $exception);
+        $safeErrorMessage = $this->safeErrorMessage($exception);
+        return parent::render($request, $exception, $safeErrorMessage);
+    }
+
+    /**
+     * Checks exception messages for POST/GET variables and removes them. Prevents dangerous things like environment variables
+     * from leaking while ensuring a meaningful and safe message can be displayed to the user (and reported to the dev team).
+     */
+    protected function safeErrorMessage($exception): string {
+        $safeErrorMessage = 'Unspecified error';
+        $exceptionMessage = $exception->getMessage();
+        if(preg_match('/(https?:\/\/.*[\?\&])/', $exceptionMessage)) {
+            $safeErrorMessage = preg_replace('/(https?:\/\/.*[\?\&][^\s]+)/', '---', $exceptionMessage);
+        }
+        else {
+            $safeErrorMessage = $exceptionMessage;
+        }
+        return $safeErrorMessage;
     }
 }

--- a/resources/views/errors/500.blade.php
+++ b/resources/views/errors/500.blade.php
@@ -22,7 +22,7 @@ Internal Server Error
                     <h3>Something just happened that wasn't supposed to happen and we're really not sure why! Please kindly report this error to <a href="mailto:wm@ztlartcc.org">wm@ztlartcc.org</a> with descriptive steps to reproduce and a link to the page. Thank you for your help!</h3>
                     <br>
                     <h3>Please include the following message in your email (if applicable):</h3>
-                    <p>{{ $exception->getMessage() }}</p>
+                    <p>{{ $safeErrorMessage }}</p>
                 </div>
                 <div class="col-sm-4">
                     <img src="/photos/this_is_fine.png" width="300px">

--- a/resources/views/errors/500.blade.php
+++ b/resources/views/errors/500.blade.php
@@ -4,6 +4,23 @@
 Internal Server Error
 @endsection
 
+@php
+/**
+    * Checks exception messages for POST/GET variables and removes them. Prevents dangerous things like environment variables
+    * from leaking while ensuring a meaningful and safe message can be displayed to the user (and reported to the dev team).
+*/
+function safeErrorMessage($exception) {
+    $safeErrorMessage = 'Unspecified error';
+    $exceptionMessage = $exception->getMessage();
+    if (preg_match('/(https?:\/\/.*[\?\&])/', $exceptionMessage)) {
+        $safeErrorMessage = preg_replace('/(https?:\/\/.*[\?\&][^\s]+)/', '---', $exceptionMessage);
+    } else {
+        $safeErrorMessage = $exceptionMessage;
+    }
+        return $safeErrorMessage;
+}
+@endphp
+
 @section('content')
 <span class="border border-light" style="background-color:#F0F0F0">
     <div class="container">
@@ -22,7 +39,7 @@ Internal Server Error
                     <h3>Something just happened that wasn't supposed to happen and we're really not sure why! Please kindly report this error to <a href="mailto:wm@ztlartcc.org">wm@ztlartcc.org</a> with descriptive steps to reproduce and a link to the page. Thank you for your help!</h3>
                     <br>
                     <h3>Please include the following message in your email (if applicable):</h3>
-                    <p>{{ $safeErrorMessage }}</p>
+                    <p>{{ safeErrorMessage($exception) }}</p>
                 </div>
                 <div class="col-sm-4">
                     <img src="/photos/this_is_fine.png" width="300px">


### PR DESCRIPTION
This PR will:
* Adds a method to the error handler that filters exception messages, removing POST/GET parameters
* Modifies the HTTP 500 error page to utilize the generated safe error message
* Close #243 
