### PR TITLE
NOISS Add null API reply protection to ARTCC Overflights method

### DIFF
--- a/app/Console/Commands/ARTCCOverflights.php
+++ b/app/Console/Commands/ARTCCOverflights.php
@@ -45,6 +45,9 @@ class ARTCCOverflights extends Command {
         DB::table('flights_within_artcc')->truncate();
 
         $result = json_decode($res->getBody());
+        if (is_null($result)) {
+            return;
+        }
         foreach ($result as $r) {
             $response = $client->get('https://api.vatsim.net/api/ratings/'.$r->cid.'/', ['headers' => ['Content-Type' => 'application/x-www-form-urlencoded','Authorization' => 'Token ' . Config::get('vatsim.api_key', '')]]);
             $res = json_decode($response->getBody(), true);


### PR DESCRIPTION
This PR will:
* Fix an error found in the laravel log file: [2023-04-10 11:10:04] production.ERROR: foreach() argument must be of type array|object, null given {"exception":"[object] (ErrorException(code: 0): foreach(
) argument must be of type array|object, null given at /home/dh_k4agrs/ztl/ztlartcc.org/app/Console/Commands/ARTCCOverflights.php:48)
