### PR TITLE
NOISS: Allows ins/mtr to update solo fields in roster

### DIFF
--- a/app/Http/Controllers/AdminDash.php
+++ b/app/Http/Controllers/AdminDash.php
@@ -451,6 +451,8 @@ class AdminDash extends Controller {
             } else {
                 $user->ctr = $request->input('ctr');
             }
+            $user->twr_solo_fields = $request->input('twr_solo_fields');
+            $user->twr_solo_expires = $request->input('twr_solo_expires');
             $user->save();
         }
 


### PR DESCRIPTION
This PR will:
* Fixes a bug identified by Simon Heck in Discord that prevented INS/MTR non-staff members from editing the solo fields on a member's roster edit page.
