### PR TITLE
#275, #286, #297: Multiple modifications to event registration methods

### DIFF
--- a/app/Http/Controllers/AdminDash.php
+++ b/app/Http/Controllers/AdminDash.php
@@ -1410,6 +1410,7 @@ class AdminDash extends Controller {
     public function assignPosition(Request $request, $id) {
         $reg = EventRegistration::find($id);
         $reg->position_id = $request->position;
+        $reg->position_id_detail = $request->position_detail;
         $reg->start_time = $request->start_time;
         $reg->end_time = $request->end_time;
         $reg->status = 1;
@@ -1436,6 +1437,7 @@ class AdminDash extends Controller {
         $reg->event_id = $id;
         $reg->controller_id = $request->controller;
         $reg->position_id = $request->position;
+        $reg->position_id_detail = $request->position_detail;
         $reg->start_time = $request->start_time;
         $reg->end_time = $request->end_time;
         $reg->status = 1;

--- a/database/migrations/2023_05_14_132500_update_event_registration_add_position_id_detail_column.php
+++ b/database/migrations/2023_05_14_132500_update_event_registration_add_position_id_detail_column.php
@@ -11,7 +11,7 @@ return new class extends Migration {
      */
     public function up() {
         Schema::table('event_registration', function ($table) {
-            $table->string('position_id_detail', 100)->default(false);
+            $table->string('position_id_detail', 100)->default('');
         });
     }
 

--- a/database/migrations/2023_05_14_132500_update_event_registration_add_position_id_detail_column.php
+++ b/database/migrations/2023_05_14_132500_update_event_registration_add_position_id_detail_column.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up() {
+        Schema::table('event_registration', function ($table) {
+            $table->string('position_id_detail', 100)->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down() {
+        Schema::table('event_registration', function ($table) {
+            $table->dropColumn('position_id_detail');
+        });
+    }
+};

--- a/database/migrations/2023_05_14_132500_update_event_registration_add_position_id_detail_column.php
+++ b/database/migrations/2023_05_14_132500_update_event_registration_add_position_id_detail_column.php
@@ -11,7 +11,7 @@ return new class extends Migration {
      */
     public function up() {
         Schema::table('event_registration', function ($table) {
-            $table->string('position_id_detail', 100)->default('');
+            $table->string('position_id_detail', 100)->nullable();
         });
     }
 

--- a/resources/views/dashboard/controllers/events/view.blade.php
+++ b/resources/views/dashboard/controllers/events/view.blade.php
@@ -86,7 +86,7 @@ View Event
                                                 <button type="button" class="btn btn-success btn-sm simple-tooltip" data-placement="top" data-toggle="tooltip" title="Assign Position"><i class="fas fa-check"></i></button>
                                             </span>
                                             &nbsp;
-                                            <a href="/dashboard/controllers/events/view/{{ $r->id }}/un-signup" style="color:inherit" data-toggle="tooltip" title="Delete Request"><i class="fas fa-times"></i></a>
+                                            <a href="/dashboard/controllers/events/view/{{ $r->id }}/un-signup" class="btn btn-danger btn-sm simple-tooltip" data-toggle="tooltip" title="Delete Request"><i class="fas fa-times"></i></a>
                                         </td>
                                     </tr>
 
@@ -217,7 +217,7 @@ View Event
                                                                     {{ $event->end_time }}z)
                                                                 @endif
                                                                 @if($c->position_id_detail != null)
-                                                                    %nbsp;
+                                                                    &nbsp;
                                                                     {{ $c->position_id_detail }}
                                                                 @endif
                                                             </i>

--- a/resources/views/dashboard/controllers/events/view.blade.php
+++ b/resources/views/dashboard/controllers/events/view.blade.php
@@ -248,15 +248,27 @@ View Event
                                                     {!! Form::text('end_time1', $your_registration1->end_time, ['placeholder' => $event->end_time, 'class' => 'form-control']) !!}
                                                 </div>
                                             @else
+                                                @if(toggleEnabled('event_assignment_toggle') && ! $event->show_assignments)
                                                 <div class="col-sm-5">
-                                                    {!! Form::select('num1', $positions->pluck('name', 'id'), $your_registration1->position_id, ['disabled', 'placeholder' => 'Choice 1', 'class' => 'form-control']) !!}
-                                                </div>
-                                                <div class="col-sm-3">
-                                                    {!! Form::text('start_time1', $your_registration1->start_time, ['disabled', 'placeholder' => $event->start_time, 'class' => 'form-control']) !!}
-                                                </div>
-                                                <div class="col-sm-3">
-                                                    {!! Form::text('end_time1', $your_registration1->end_time, ['disabled', 'placeholder' => $event->end_time, 'class' => 'form-control']) !!}
-                                                </div>
+                                                        {!! Form::select('num1', $positions->pluck('name', 'id'), $your_registration1->position_id, ['disabled', 'placeholder' => 'Choice 1', 'class' => 'form-control']) !!}
+                                                    </div>
+                                                    <div class="col-sm-3">
+                                                        {!! Form::text('start_time1', null, ['disabled', 'placeholder' => $event->start_time, 'class' => 'form-control']) !!}
+                                                    </div>
+                                                    <div class="col-sm-3">
+                                                        {!! Form::text('end_time1', null, ['disabled', 'placeholder' => $event->end_time, 'class' => 'form-control']) !!}
+                                                    </div>
+                                                @else
+                                                    <div class="col-sm-5">
+                                                        {!! Form::select('num1', $positions->pluck('name', 'id'), $your_registration1->position_id, ['disabled', 'placeholder' => 'Choice 1', 'class' => 'form-control']) !!}
+                                                    </div>
+                                                    <div class="col-sm-3">
+                                                        {!! Form::text('start_time1', $your_registration1->start_time, ['disabled', 'placeholder' => $event->start_time, 'class' => 'form-control']) !!}
+                                                    </div>
+                                                    <div class="col-sm-3">
+                                                        {!! Form::text('end_time1', $your_registration1->end_time, ['disabled', 'placeholder' => $event->end_time, 'class' => 'form-control']) !!}
+                                                    </div>
+                                                @endif
                                             @endif
                                         </div>
                                     @else

--- a/resources/views/dashboard/controllers/events/view.blade.php
+++ b/resources/views/dashboard/controllers/events/view.blade.php
@@ -85,6 +85,8 @@ View Event
                                             <span data-toggle="modal" data-target="#addrequest{{ $r->id }}">
                                                 <button type="button" class="btn btn-success btn-sm simple-tooltip" data-placement="top" data-toggle="tooltip" title="Assign Position"><i class="fas fa-check"></i></button>
                                             </span>
+                                            &nbsp;
+                                            <a href="/dashboard/controllers/events/view/{{ $r->id }}/un-signup" style="color:inherit" data-toggle="tooltip" title="Delete Request"><i class="fas fa-times"></i></a>
                                         </td>
                                     </tr>
 
@@ -206,6 +208,11 @@ View Event
                                                                 @else
                                                                     {{ $event->end_time }}z)
                                                                 @endif
+                                                                @if($c->position_id_detail != null)
+                                                                    %nbsp;
+                                                                    {{ $c->position_id_detail }}
+                                                                @else
+
                                                             </i>
                                                         </b>
                                                     </p>
@@ -248,27 +255,19 @@ View Event
                                                     {!! Form::text('end_time1', $your_registration1->end_time, ['placeholder' => $event->end_time, 'class' => 'form-control']) !!}
                                                 </div>
                                             @else
-                                                @if(toggleEnabled('event_assignment_toggle') && ! $event->show_assignments)
                                                 <div class="col-sm-5">
+                                                    @if(toggleEnabled('event_assignment_toggle') && ! $event->show_assignments)
+                                                        {!! Form::select('num1', $positions->pluck('name', 'id'), null, ['disabled', 'placeholder' => 'Pending...', 'class' => 'form-control']) !!}
+                                                    @else
                                                         {!! Form::select('num1', $positions->pluck('name', 'id'), $your_registration1->position_id, ['disabled', 'placeholder' => 'Choice 1', 'class' => 'form-control']) !!}
-                                                    </div>
-                                                    <div class="col-sm-3">
-                                                        {!! Form::text('start_time1', null, ['disabled', 'placeholder' => $event->start_time, 'class' => 'form-control']) !!}
-                                                    </div>
-                                                    <div class="col-sm-3">
-                                                        {!! Form::text('end_time1', null, ['disabled', 'placeholder' => $event->end_time, 'class' => 'form-control']) !!}
-                                                    </div>
-                                                @else
-                                                    <div class="col-sm-5">
-                                                        {!! Form::select('num1', $positions->pluck('name', 'id'), $your_registration1->position_id, ['disabled', 'placeholder' => 'Choice 1', 'class' => 'form-control']) !!}
-                                                    </div>
-                                                    <div class="col-sm-3">
-                                                        {!! Form::text('start_time1', $your_registration1->start_time, ['disabled', 'placeholder' => $event->start_time, 'class' => 'form-control']) !!}
-                                                    </div>
-                                                    <div class="col-sm-3">
-                                                        {!! Form::text('end_time1', $your_registration1->end_time, ['disabled', 'placeholder' => $event->end_time, 'class' => 'form-control']) !!}
-                                                    </div>
-                                                @endif
+                                                    @endif
+                                                </div>
+                                                <div class="col-sm-3">
+                                                    {!! Form::text('start_time1', $your_registration1->start_time, ['disabled', 'placeholder' => $event->start_time, 'class' => 'form-control']) !!}
+                                                </div>
+                                                <div class="col-sm-3">
+                                                    {!! Form::text('end_time1', $your_registration1->end_time, ['disabled', 'placeholder' => $event->end_time, 'class' => 'form-control']) !!}
+                                                </div>
                                             @endif
                                         </div>
                                     @else

--- a/resources/views/dashboard/controllers/events/view.blade.php
+++ b/resources/views/dashboard/controllers/events/view.blade.php
@@ -116,6 +116,14 @@ View Event
                                                     </div>
                                                     <div class="form-group">
                                                         <div class="row">
+                                                            <div class="col-sm-12">
+                                                                {!! Form::label('position_detail', 'Position or sector ID assigned') !!}
+                                                                {!! Form::text('position_detail', null, ['class' => 'form-control']) !!}
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                    <div class="form-group">
+                                                        <div class="row">
                                                             <div class="col-sm-6">
                                                                 {!! Form::label('start_time', 'Start Time (Zulu)') !!}
                                                                 {!! Form::text('start_time', $r->start_time, ['placeholder' => $event->start_time, 'class' => 'form-control']) !!}
@@ -451,6 +459,14 @@ View Event
 								</div>
 							</div>
 						</div>
+                        <div class="form-group">
+                            <div class="row">
+                                <div class="col-sm-12">
+                                    {!! Form::label('position_detail', 'Position or sector ID assigned') !!}
+                                    {!! Form::text('position_detail', null, ['class' => 'form-control']) !!}
+                                </div>
+                            </div>
+                        </div>
 						<div class="form-group">
 							<div class="row">
 								<div class="col-sm-6">

--- a/resources/views/dashboard/controllers/events/view.blade.php
+++ b/resources/views/dashboard/controllers/events/view.blade.php
@@ -293,8 +293,9 @@ View Event
                                     @endif
                                 </div>
                                 <div class="form-group inline">
+                                    @if(!$your_registration1)
                                     <button type="submit" class="btn btn-success">Submit</button>
-                                    @if($your_registration1)
+                                    @else
                                         <a href="/dashboard/controllers/events/view/{{ $your_registration1->id }}/un-signup" class="btn btn-danger">Delete your Signup</a>
                                     @endif
                                 </div>

--- a/resources/views/dashboard/controllers/events/view.blade.php
+++ b/resources/views/dashboard/controllers/events/view.blade.php
@@ -219,8 +219,7 @@ View Event
                                                                 @if($c->position_id_detail != null)
                                                                     %nbsp;
                                                                     {{ $c->position_id_detail }}
-                                                                @else
-
+                                                                @endif
                                                             </i>
                                                         </b>
                                                     </p>

--- a/resources/views/emails/event_reminder.blade.php
+++ b/resources/views/emails/event_reminder.blade.php
@@ -11,7 +11,11 @@
     <ul>
         @foreach($positions as $p)
             <li>
-                {{ $p->controller_name }} - {{ $p->position_name }}
+                @if(($positions->status == 1)&&($event->show_assignments == 1))
+                    {{ $p->controller_name }} - {{ $p->position_name }}
+                @else
+                    {{ $p->controller_name }} - position assignment pending
+                @endif
                 <i>
                     @if($p->start_time != null)
                         ({{ $p->start_time }}

--- a/resources/views/emails/event_reminder.blade.php
+++ b/resources/views/emails/event_reminder.blade.php
@@ -11,7 +11,7 @@
     <ul>
         @foreach($positions as $p)
             <li>
-                @if(($positions->status == 1)&&($event->show_assignments == 1))
+                @if($positions->status == 1 && ($event->show_assignments || toggle_enabled('event_assignment_toggle')))
                     {{ $p->controller_name }} - {{ $p->position_name }}
                 @else
                     {{ $p->controller_name }} - position assignment pending


### PR DESCRIPTION
This PR will:
* Addresses an issue where event sign-up information is visible in the registration form before the event visibility is toggled on
* Adds position assignment detail field to EC's controls to input specific position identifier (ex. C43) without overriding the start or end time fields
* Allows staff to delete member event registrations (to remove duplicates)
* Close #275 
* Close #286 
* Close #297 
