### PR TITLE
NOISS: Correct event reminder email bug

### DIFF
--- a/app/Console/Commands/EventEmails.php
+++ b/app/Console/Commands/EventEmails.php
@@ -46,7 +46,7 @@ class EventEmails extends Command {
         }
 
         if ($event != null) {
-            $positions = EventRegistration::where('status', 1)->where('event_id', $event->id)->get()->sortBy(function ($a) use ($event) {
+            $positions = EventRegistration::where('event_id', $event->id)->get()->sortBy(function ($a) use ($event) {
                 if ($a->start_time == null) {
                     return $event->start_time;
                 } else {

--- a/resources/views/emails/event_reminder.blade.php
+++ b/resources/views/emails/event_reminder.blade.php
@@ -11,7 +11,7 @@
     <ul>
         @foreach($positions as $p)
             <li>
-                @if($positions->status == 1 && ($event->show_assignments || toggle_enabled('event_assignment_toggle')))
+                @if(strlen($p->position_name) > 0 && ($event->show_assignments || toggle_enabled('event_assignment_toggle')))
                     {{ $p->controller_name }} - {{ $p->position_name }}
                 @else
                     {{ $p->controller_name }} - position assignment pending


### PR DESCRIPTION
This PR will:
* Corrects a bug associated with the update to email event reminders. $position->status is out of scope in the blade, causing a 500 error when executing the email reminder command.
* I overlooked the status == 1 limitation which would prevent controllers with an event registration but no position assignment from getting a generic reminder email (EC's request). This PR removes the status == 1 restriction.