### PR TITLE
#303, #304 Updates events team permissions & roles

### DIFF
--- a/app/Http/Controllers/AdminDash.php
+++ b/app/Http/Controllers/AdminDash.php
@@ -327,7 +327,7 @@ class AdminDash extends Controller {
             $user->visitor_from = $request->input('visitor_from');
             $user->save();
 
-            if ($user->hasRole(['atm', 'datm', 'ta', 'ata', 'wm', 'awm', 'fe', 'afe', 'ec', 'aec']) == true) {
+            if ($user->hasRole(['atm', 'datm', 'ta', 'ata', 'wm', 'awm', 'fe', 'afe', 'ec', 'aec','aec-ghost','events-team']) == true) {
                 if ($user->hasRole('atm')) {
                     $user->detachRole('atm');
                 } elseif ($user->hasRole('datm')) {
@@ -348,6 +348,10 @@ class AdminDash extends Controller {
                     $user->detachRole('ec');
                 } elseif ($user->hasRole('aec')) {
                     $user->detachRole('aec');
+                } elseif ($user->hasRole('aec-ghost')) {
+                    $user->detachRole('aec-ghost');
+                } elseif ($user->hasRole('events-team')) {
+                    $user->detachRole('events-team');
                 }
             }
 
@@ -371,6 +375,10 @@ class AdminDash extends Controller {
                 $user->attachRole('ec');
             } elseif ($request->input('staff') == 10) {
                 $user->attachRole('aec');
+            } elseif ($request->input('staff') == 11) {
+                $user->attachRole('aec-ghost');
+            } elseif ($request->input('staff') == 12) {
+                $user->attachRole('events-team');
             }
 
             if ($user->hasRole(['mtr', 'ins']) == true) {

--- a/app/Http/Controllers/ControllerDash.php
+++ b/app/Http/Controllers/ControllerDash.php
@@ -363,7 +363,7 @@ class ControllerDash extends Controller {
     public function viewEvent($id) {
         $event = Event::find($id);
         $positions = EventPosition::where('event_id', $event->id)->orderBy('created_at', 'ASC')->get();
-        if (Auth::user()->isAbleTo('events')) {
+        if (Auth::user()->isAbleTo('events')||Auth::user()->hasRole('events-team')) {
             $registrations = EventRegistration::where('event_id', $event->id)->where('status', 0)->orderBy('created_at', 'ASC')->get();
             $presets = PositionPreset::get()->pluck('name', 'id');
             $controllers = User::orderBy('lname', 'ASC')->get()->pluck('backwards_name_rating', 'id');

--- a/app/Http/Controllers/ControllerDash.php
+++ b/app/Http/Controllers/ControllerDash.php
@@ -345,7 +345,7 @@ class ControllerDash extends Controller {
     }
 
     public function showEvents() {
-        if (Auth::user()->isAbleTo('events')) {
+        if (Auth::user()->isAbleTo('events')||Auth::user()->hasRole('events-team')) {
             $events = Event::where('status', 0)->orWhere('status', 1)->get()->sortByDesc(function ($e) {
                 return strtotime($e->date);
             });

--- a/app/User.php
+++ b/app/User.php
@@ -134,6 +134,10 @@ class User extends Authenticatable {
             return 9;
         } elseif ($this->hasRole('aec')) {
             return 10;
+        } elseif ($this->hasRole('aec-ghost')) {
+            return 11;
+        } elseif ($this->hasRole('events-team')) {
+            return 12;
         } else {
             return 0;
         }

--- a/database/seeders/LaratrustSeeder.php
+++ b/database/seeders/LaratrustSeeder.php
@@ -480,7 +480,7 @@ class LaratrustSeeder extends Seeder {
             'role_id' => 12
         ]);
         DB::table('permission_role')->insert([
-            'permission_id' => 9,
+            'permission_id' => 10,
             'role_id' => 13
         ]);
     }

--- a/database/seeders/LaratrustSeeder.php
+++ b/database/seeders/LaratrustSeeder.php
@@ -61,6 +61,14 @@ class LaratrustSeeder extends Seeder {
              'name' => 'ins',
              'display_name' => 'Instructor'
         ]);
+        DB::table('roles')->insert([
+            'name' => 'aec-ghost',
+            'display_name' => 'Assistant Events Coordinator (Ghost)'
+       ]);
+        DB::table('roles')->insert([
+            'name' => 'events-team',
+            'display_name' => 'Events Team Member'
+       ]);
         
         // Adds Permissions to the Permissions Table
         DB::table('permissions')->insert([
@@ -470,6 +478,10 @@ class LaratrustSeeder extends Seeder {
         DB::table('permission_role')->insert([
             'permission_id' => 11,
             'role_id' => 12
+        ]);
+        DB::table('permission_role')->insert([
+            'permission_id' => 9,
+            'role_id' => 13
         ]);
     }
 }

--- a/resources/views/dashboard/admin/roster/edit.blade.php
+++ b/resources/views/dashboard/admin/roster/edit.blade.php
@@ -201,6 +201,8 @@ Update Controller
                                 8 => 'AFE',
                                 9 => 'EC',
                                 10 => 'AEC'
+                                11 => 'AEC (Ghost)'
+                                12 => 'Events Team'
                             ], $user->staff_position, ['class' => 'form-control']) !!}
                         @endif
                     </div>
@@ -245,6 +247,8 @@ Update Controller
                                 8 => 'AFE',
                                 9 => 'EC',
                                 10 => 'AEC'
+                                11 => 'AEC (Ghost)'
+                                12 => 'Events Team'
                             ], $user->staff_position, ['class' => 'form-control', 'disabled']) !!}
                         @endif
                     </div>

--- a/resources/views/dashboard/admin/roster/edit.blade.php
+++ b/resources/views/dashboard/admin/roster/edit.blade.php
@@ -200,8 +200,8 @@ Update Controller
                                 7 => 'FE',
                                 8 => 'AFE',
                                 9 => 'EC',
-                                10 => 'AEC'
-                                11 => 'AEC (Ghost)'
+                                10 => 'AEC',
+                                11 => 'AEC (Ghost)',
                                 12 => 'Events Team'
                             ], $user->staff_position, ['class' => 'form-control']) !!}
                         @endif
@@ -246,8 +246,8 @@ Update Controller
                                 7 => 'FE',
                                 8 => 'AFE',
                                 9 => 'EC',
-                                10 => 'AEC'
-                                11 => 'AEC (Ghost)'
+                                10 => 'AEC',
+                                11 => 'AEC (Ghost)',
                                 12 => 'Events Team'
                             ], $user->staff_position, ['class' => 'form-control', 'disabled']) !!}
                         @endif

--- a/resources/views/dashboard/controllers/events/view.blade.php
+++ b/resources/views/dashboard/controllers/events/view.blade.php
@@ -193,7 +193,7 @@ View Event
                                     <tr>
                                         <td>{{ $p->name }}</td>
                                         <td>
-                                            @if($p->controller->count() == 0 || (toggleEnabled('event_assignment_toggle') && ! Auth::user()->isAbleTo('events') && ! $event->show_assignments))
+                                            @if($p->controller->count() == 0 || (toggleEnabled('event_assignment_toggle') && (! Auth::user()->isAbleTo('events') || ! Auth::user()->hasRole('events-team')) && ! $event->show_assignments))
                                                 No Assignment
                                             @else
                                                 @foreach($p->controller as $c)

--- a/resources/views/dashboard/controllers/events/view.blade.php
+++ b/resources/views/dashboard/controllers/events/view.blade.php
@@ -35,7 +35,7 @@ View Event
                     <p>{!! $event->description !!}</p>
                 </div>
             </div>
-            @if(Auth::user()->isAbleTo('events'))
+            @if(Auth::user()->isAbleTo('events')||Auth::user()->hasRole('events-team'))
                 <br>
                 <div class="card">
                     <div class="card-header">
@@ -44,12 +44,14 @@ View Event
                         </h3>
                     </div>
                     <div class="card-body">
+                        @if(Auth::user()->isAbleTo('events'))
                         <p>
                             <i>Assign Positions:</i>
                             <span class="float-right" data-toggle="modal" data-target="#manualAssign">
                                     <button type="button" class="btn btn-success btn-sm pull-right" data-placement="top">Manual Assign</button>
                                 </span>
                         </p>
+                        @endif
                         <table class="table">
                             <thead>
                             <tr>
@@ -57,7 +59,9 @@ View Event
                                 <th scope="col">Position</th>
                                 <th scope="col">Controller</th>
                                 <th scope="col">Availability</th>
+                                @if(Auth::user()->isAbleTo('events'))
                                 <th scope="col">Actions</th>
+                                @endif
                             </tr>
                             </thead>
                             <tbody>
@@ -81,6 +85,7 @@ View Event
                                                 {{ $event->end_time }}z
                                             @endif
                                         </td>
+                                        @if(Auth::user()->isAbleTo('events'))
                                         <td>
                                             <span data-toggle="modal" data-target="#addrequest{{ $r->id }}">
                                                 <button type="button" class="btn btn-success btn-sm simple-tooltip" data-placement="top" data-toggle="tooltip" title="Assign Position"><i class="fas fa-check"></i></button>
@@ -88,6 +93,7 @@ View Event
                                             &nbsp;
                                             <a href="/dashboard/controllers/events/view/{{ $r->id }}/un-signup" class="btn btn-danger btn-sm simple-tooltip" data-toggle="tooltip" title="Delete Request"><i class="fas fa-times"></i></a>
                                         </td>
+                                        @endif
                                     </tr>
 
                                     <div class="modal fade" id="addrequest{{ $r->id }}" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
@@ -193,7 +199,7 @@ View Event
                                     <tr>
                                         <td>{{ $p->name }}</td>
                                         <td>
-                                            @if($p->controller->count() == 0 || (toggleEnabled('event_assignment_toggle') && (! Auth::user()->isAbleTo('events') || ! Auth::user()->hasRole('events-team')) && ! $event->show_assignments))
+                                            @if($p->controller->count() == 0 || (toggleEnabled('event_assignment_toggle') && ! Auth::user()->isAbleTo('events') && ! $event->show_assignments))
                                                 No Assignment
                                             @else
                                                 @foreach($p->controller as $c)

--- a/resources/views/dashboard/controllers/events/view.blade.php
+++ b/resources/views/dashboard/controllers/events/view.blade.php
@@ -45,12 +45,12 @@ View Event
                     </div>
                     <div class="card-body">
                         @if(Auth::user()->isAbleTo('events'))
-                        <p>
-                            <i>Assign Positions:</i>
-                            <span class="float-right" data-toggle="modal" data-target="#manualAssign">
+                            <p>
+                                <i>Assign Positions:</i>
+                                <span class="float-right" data-toggle="modal" data-target="#manualAssign">
                                     <button type="button" class="btn btn-success btn-sm pull-right" data-placement="top">Manual Assign</button>
                                 </span>
-                        </p>
+                            </p>
                         @endif
                         <table class="table">
                             <thead>
@@ -86,13 +86,13 @@ View Event
                                             @endif
                                         </td>
                                         @if(Auth::user()->isAbleTo('events'))
-                                        <td>
-                                            <span data-toggle="modal" data-target="#addrequest{{ $r->id }}">
-                                                <button type="button" class="btn btn-success btn-sm simple-tooltip" data-placement="top" data-toggle="tooltip" title="Assign Position"><i class="fas fa-check"></i></button>
-                                            </span>
-                                            &nbsp;
-                                            <a href="/dashboard/controllers/events/view/{{ $r->id }}/un-signup" class="btn btn-danger btn-sm simple-tooltip" data-toggle="tooltip" title="Delete Request"><i class="fas fa-times"></i></a>
-                                        </td>
+                                            <td>
+                                                <span data-toggle="modal" data-target="#addrequest{{ $r->id }}">
+                                                    <button type="button" class="btn btn-success btn-sm simple-tooltip" data-placement="top" data-toggle="tooltip" title="Assign Position"><i class="fas fa-check"></i></button>
+                                                </span>
+                                                &nbsp;
+                                                <a href="/dashboard/controllers/events/view/{{ $r->id }}/un-signup" class="btn btn-danger btn-sm simple-tooltip" data-toggle="tooltip" title="Delete Request"><i class="fas fa-times"></i></a>
+                                            </td>
                                         @endif
                                     </tr>
 

--- a/resources/views/inc/sidebar.blade.php
+++ b/resources/views/inc/sidebar.blade.php
@@ -43,7 +43,7 @@
                 @endif
             </div>
         @endif
-        @if(Auth::user()->isAbleTo('staff') || Auth::user()->isAbleTo('email') || Auth::user()->isAbleTo('scenery') || Auth::user()->isAbleTo('files') || Auth::user()->isAbleTo('events'))
+        @if(Auth::user()->isAbleTo('staff') || Auth::user()->isAbleTo('email') || Auth::user()->isAbleTo('scenery') || Auth::user()->isAbleTo('files'))
             <div class="dropdown-divider"></div>
             <p class="collapsible-admin" style="margin-left:-20px; cursor:pointer">
                 ADMINISTRATION


### PR DESCRIPTION
This PR will:
* Adds a "AEC Ghost" role, allowing the EC to grant AEC permissions to someone without that user being assigned the AEC tag on the roster or being listed as an AEC on the staff page.
* Adds an "Event Team" role, allowing assigned users to see hidden events and permission assignments (read-only)
* Close #303 
* Close #304 
