### PR TITLE
NOISS: Adds events_team visibility permission

### DIFF
--- a/resources/views/dashboard/controllers/events/view.blade.php
+++ b/resources/views/dashboard/controllers/events/view.blade.php
@@ -199,7 +199,7 @@ View Event
                                     <tr>
                                         <td>{{ $p->name }}</td>
                                         <td>
-                                            @if($p->controller->count() == 0 || (toggleEnabled('event_assignment_toggle') && ! Auth::user()->isAbleTo('events') && ! $event->show_assignments))
+                                            @if($p->controller->count() == 0 || (toggleEnabled('event_assignment_toggle') && ! (Auth::user()->isAbleTo('events') || Auth::user()->hasRole('events-team')) && ! $event->show_assignments))
                                                 No Assignment
                                             @else
                                                 @foreach($p->controller as $c)


### PR DESCRIPTION
This PR will:
* Fix a bug currently preventing members with the events_team role from viewing event signups when they are hidden