### PR TITLE
#311 Add limited roster edit perms for EC

### DIFF
--- a/app/Http/Controllers/AdminDash.php
+++ b/app/Http/Controllers/AdminDash.php
@@ -327,7 +327,7 @@ class AdminDash extends Controller {
             $user->visitor_from = $request->input('visitor_from');
             $user->save();
 
-            if ($user->hasRole(['atm', 'datm', 'ta', 'ata', 'wm', 'awm', 'fe', 'afe', 'ec', 'aec','aec-ghost','events-team']) == true) {
+            if ($user->hasRole(['atm', 'datm', 'ta', 'ata', 'wm', 'awm', 'fe', 'afe', 'ec']) == true) {
                 if ($user->hasRole('atm')) {
                     $user->detachRole('atm');
                 } elseif ($user->hasRole('datm')) {
@@ -346,12 +346,6 @@ class AdminDash extends Controller {
                     $user->detachRole('afe');
                 } elseif ($user->hasRole('ec')) {
                     $user->detachRole('ec');
-                } elseif ($user->hasRole('aec')) {
-                    $user->detachRole('aec');
-                } elseif ($user->hasRole('aec-ghost')) {
-                    $user->detachRole('aec-ghost');
-                } elseif ($user->hasRole('events-team')) {
-                    $user->detachRole('events-team');
                 }
             }
 
@@ -373,11 +367,23 @@ class AdminDash extends Controller {
                 $user->attachRole('afe');
             } elseif ($request->input('staff') == 9) {
                 $user->attachRole('ec');
-            } elseif ($request->input('staff') == 10) {
+            }
+
+            if ($user->hasRole(['aec','aec-ghost','events-team']) == true) {
+                if ($user->hasRole('aec')) {
+                    $user->detachRole('aec');
+                } elseif ($user->hasRole('aec-ghost')) {
+                    $user->detachRole('aec-ghost');
+                } elseif ($user->hasRole('events-team')) {
+                    $user->detachRole('events-team');
+                }
+            }
+
+            if ($request->input('events_staff') == 1) {
                 $user->attachRole('aec');
-            } elseif ($request->input('staff') == 11) {
+            } elseif ($request->input('events_staff') == 2) {
                 $user->attachRole('aec-ghost');
-            } elseif ($request->input('staff') == 12) {
+            } elseif ($request->input('events_staff') == 3) {
                 $user->attachRole('events-team');
             }
 
@@ -390,6 +396,7 @@ class AdminDash extends Controller {
                     $user->save();
                 }
             }
+
             if ($request->input('training') == 1) {
                 $user->attachRole('mtr');
                 if ($user->train_pwr == null) {

--- a/app/User.php
+++ b/app/User.php
@@ -143,6 +143,18 @@ class User extends Authenticatable {
         }
     }
 
+    public function getEventsPositionAttribute() {
+        if ($this->hasRole('aec')) {
+            return 1;
+        } elseif ($this->hasrole('aec-ghost')) {
+            return 2;
+        } elseif ($this->hasrole('events-team')) {
+            return 3;
+        } else {
+            return 0;
+        }
+    }
+
     public function getTrainPositionAttribute() {
         if ($this->hasRole('mtr')) {
             return 1;

--- a/resources/views/dashboard/admin/roster/edit.blade.php
+++ b/resources/views/dashboard/admin/roster/edit.blade.php
@@ -200,9 +200,6 @@ Update Controller
                                 7 => 'FE',
                                 8 => 'AFE',
                                 9 => 'EC',
-                                10 => 'AEC',
-                                11 => 'AEC (Ghost)',
-                                12 => 'Events Team'
                             ], $user->staff_position, ['class' => 'form-control']) !!}
                         @endif
                     </div>
@@ -246,9 +243,6 @@ Update Controller
                                 7 => 'FE',
                                 8 => 'AFE',
                                 9 => 'EC',
-                                10 => 'AEC',
-                                11 => 'AEC (Ghost)',
-                                12 => 'Events Team'
                             ], $user->staff_position, ['class' => 'form-control', 'disabled']) !!}
                         @endif
                     </div>
@@ -287,7 +281,6 @@ Update Controller
                                 7 => 'FE',
                                 8 => 'AFE',
                                 9 => 'EC',
-                                10 => 'AEC'
                             ], $user->staff_position, ['class' => 'form-control']) !!}
                         @else
                             {!! Form::label('training', 'Training Position') !!}
@@ -317,7 +310,6 @@ Update Controller
                                 7 => 'FE',
                                 8 => 'AFE',
                                 9 => 'EC',
-                                10 => 'AEC'
                             ], $user->staff_position, ['class' => 'form-control', 'disabled']) !!}
                         @else
                             {!! Form::label('training', 'Training Position') !!}
@@ -344,6 +336,15 @@ Update Controller
                             ], $user->train_position, ['class' => 'form-control']) !!}
                         @endif
                     </div>
+                    <div class="col-sm-6">
+                        {!! Form::label('events_staff', 'Events Staff') !!}
+                        {!! Form::select('events_staff', [
+                            0 => 'NONE',
+                            1 => 'AEC',
+                            2 => 'AEC (Ghost)',
+                            3 => 'Events Team'
+                            ], $user->events_position, ['class' => 'form-control']) !!}
+                    </div>
                 </div>
             </div>
         @else
@@ -359,6 +360,27 @@ Update Controller
                             ], $user->train_position, ['class' => 'form-control', 'disabled']) !!}
                         @endif
                     </div>
+                    @if(Auth::user()->isAbleTo('events'))
+                    <div class="col-sm-6">
+                        {!! Form::label('events_staff', 'Events Staff') !!}
+                        {!! Form::select('events_staff', [
+                            0 => 'NONE',
+                            1 => 'AEC',
+                            2 => 'AEC (Ghost)',
+                            3 => 'Events Team'
+                            ], $user->events_position, ['class' => 'form-control']) !!}
+                    </div>
+                    @else
+                    <div class="col-sm-6">
+                        {!! Form::label('events_staff', 'Events Staff') !!}
+                        {!! Form::select('events_staff', [
+                            0 => 'NONE',
+                            1 => 'AEC',
+                            2 => 'AEC (Ghost)',
+                            3 => 'Events Team'
+                            ], $user->events_position, ['class' => 'form-control', 'disabled']) !!}
+                    </div>
+                    @endif
                 </div>
             </div>
         @endif

--- a/resources/views/dashboard/admin/roster/edit.blade.php
+++ b/resources/views/dashboard/admin/roster/edit.blade.php
@@ -34,13 +34,23 @@ Update Controller
                 </div>
                 <div class="col-sm-6">
                     {!! Form::label('del', 'Delivery Certification') !!}
-                    {!! Form::select('del', [
-                        0 => 'None',
-                        1 => 'Minor Certified',
-                        88 => 'Minor Monitoring',
-                        89 => 'Major Monitoring',
-                        2 => 'Major Certified'
-                    ], $user->del, ['class' => 'form-control']) !!}
+                    @if(Auth::user()->isAbleTo('roster') || Auth::user()->isAbleTo('train'))
+                        {!! Form::select('del', [
+                            0 => 'None',
+                            1 => 'Minor Certified',
+                            88 => 'Minor Monitoring',
+                            89 => 'Major Monitoring',
+                            2 => 'Major Certified'
+                        ], $user->del, ['class' => 'form-control']) !!}
+                    @else
+                        {!! Form::select('del', [
+                            0 => 'None',
+                            1 => 'Minor Certified',
+                            88 => 'Minor Monitoring',
+                            89 => 'Major Monitoring',
+                            2 => 'Major Certified'
+                        ], $user->del, ['class' => 'form-control', 'disabled']) !!}
+                    @endif
                 </div>
             </div>
         </div>
@@ -52,11 +62,19 @@ Update Controller
                 </div>
                 <div class="col-sm-6">
                     {!! Form::label('gnd', 'Ground Certification') !!}
-                    {!! Form::select('gnd', [
-                        0 => 'None',
-                        1 => 'Minor Certified',
-                        2 => 'Major Certified'
-                    ], $user->gnd, ['class' => 'form-control']) !!}
+                    @if(Auth::user()->isAbleTo('roster') || Auth::user()->isAbleTo('train'))
+                        {!! Form::select('gnd', [
+                            0 => 'None',
+                            1 => 'Minor Certified',
+                            2 => 'Major Certified'
+                        ], $user->gnd, ['class' => 'form-control']) !!}
+                    @else
+                        {!! Form::select('gnd', [
+                            0 => 'None',
+                            1 => 'Minor Certified',
+                            2 => 'Major Certified'
+                        ], $user->gnd, ['class' => 'form-control', 'disabled']) !!}
+                    @endif
                 </div>
             </div>
         </div>
@@ -68,49 +86,41 @@ Update Controller
                 </div>
                 <div class="col-sm-6">
                     {!! Form::label('twr', 'Tower Certification') !!}
+                    @if(Auth::user()->isAbleTo('roster') || Auth::user()->isAbleTo('train'))
+                        {!! Form::select('twr', [
+                            0 => 'None',
+                            99 => 'Solo Certification',
+                            1 => 'Minor Certified',
+                            88 => 'Minor Montoring',
+                            89 => 'Major Montoring',
+                            2 => 'Major Certified'
+                        ], $user->twr, ['class' => 'form-control']) !!}
+                    @else
                     {!! Form::select('twr', [
-                        0 => 'None',
-                        99 => 'Solo Certification',
-                        1 => 'Minor Certified',
-                        88 => 'Minor Montoring',
-                        89 => 'Major Montoring',
-                        2 => 'Major Certified'
-                    ], $user->twr, ['class' => 'form-control']) !!}
+                            0 => 'None',
+                            99 => 'Solo Certification',
+                            1 => 'Minor Certified',
+                            88 => 'Minor Montoring',
+                            89 => 'Major Montoring',
+                            2 => 'Major Certified'
+                        ], $user->twr, ['class' => 'form-control', 'disabled']) !!}
+                    @endif
                 </div>
             </div>
         </div>
-        @if(Auth::user()->isAbleTo('roster'))
-            <div class="form-group">
-                <div class="row">
-                    <div class="col-sm-6">
-                        {!! Form::label('initials', 'Initials') !!}
+        <div class="form-group">
+            <div class="row">
+                <div class="col-sm-6">
+                    {!! Form::label('initials', 'Initials') !!}
+                    @if(Auth::user()->isAbleTo('roster'))
                         {!! Form::text('initials', $user->initials, ['class' => 'form-control']) !!}
-                    </div>
-                    <div class="col-sm-6">
-                        {!! Form::label('app', 'Approach Certification') !!}
-                        {!! Form::select('app', [
-                            0 => 'None',
-                            99 => 'Solo Certification',
-                            1 => 'Minor Certified',
-                            88 => 'Minor Montoring',
-                        89 => 'Major Montoring',
-                        90 => 'A80 SAT Certified',
-                        91 => 'A80 DR Certified',
-                        92 => 'A80 TAR Certified',
-                            2 => 'Major Certified'
-                        ], $user->app, ['class' => 'form-control']) !!}
-                    </div>
-                </div>
-            </div>
-        @else
-            <div class="form-group">
-                <div class="row">
-                    <div class="col-sm-6">
-                        {!! Form::label('initials', 'Initials') !!}
+                    @else
                         {!! Form::text('initials', $user->initials, ['class' => 'form-control', 'disabled']) !!}
-                    </div>
-                    <div class="col-sm-6">
-                        {!! Form::label('app', 'Approach Certification') !!}
+                    @endif
+                </div>
+                <div class="col-sm-6">
+                    {!! Form::label('app', 'Approach Certification') !!}
+                    @if(Auth::user()->isAbleTo('roster') || Auth::user()->isAbleTo('train'))
                         {!! Form::select('app', [
                             0 => 'None',
                             99 => 'Solo Certification',
@@ -122,14 +132,26 @@ Update Controller
                         92 => 'A80 TAR Certified',
                             2 => 'Major Certified'
                         ], $user->app, ['class' => 'form-control']) !!}
-                    </div>
+                    @else
+                        {!! Form::select('app', [
+                            0 => 'None',
+                            99 => 'Solo Certification',
+                            1 => 'Minor Certified',
+                            88 => 'Minor Montoring',
+                            89 => 'Major Montoring',
+                            90 => 'A80 SAT Certified',
+                            91 => 'A80 DR Certified',
+                            92 => 'A80 TAR Certified',
+                            2 => 'Major Certified'
+                        ], $user->app, ['class' => 'form-control', 'disabled']) !!}
+                    @endif
                 </div>
             </div>
-        @endif
-        @if(Auth::user()->isAbleTo('roster'))
-            <div class="form-group">
-                <div class="row">
-                    <div class="col-sm-6">
+        </div>
+        <div class="form-group">
+            <div class="row">
+                <div class="col-sm-6">
+                    @if(Auth::user()->isAbleTo('roster'))
                         @if($user->visitor == 1)
                             {!! Form::label('visitor_from', 'Visitor From') !!}
                             {!! Form::text('visitor_from', $user->visitor_from, ['class' => 'form-control']) !!}
@@ -140,68 +162,129 @@ Update Controller
                                 0 => 'LOA'
                             ], $user->status, ['class' => 'form-control']) !!}
                         @endif
-                    </div>
-                    <div class="col-sm-6">
-                        {!! Form::label('ctr', 'Center Certification') !!}
-                        {!! Form::select('ctr', [
-                            0 => 'None',
-                            99 => 'Solo Certification',
-                            1 => 'Certified'
-                        ], $user->ctr, ['class' => 'form-control']) !!}
-                    </div>
-                </div>
-            </div>
-        @else
-            <div class="form-group">
-                <div class="row">
-                    <div class="col-sm-6">
-                        @if($user->visitor == 1)
+                    @else
+                    @if($user->visitor == 1)
                             {!! Form::label('visitor_from', 'Visitor From') !!}
                             {!! Form::text('visitor_from', $user->visitor_from, ['class' => 'form-control', 'disabled']) !!}
-                        @else
-                            {!! Form::label('status', 'Status') !!}
-                            {!! Form::select('status', [
-                                1 => 'Active',
-                                0 => 'LOA'
-                            ], $user->status, ['class' => 'form-control', 'disabled']) !!}
-                        @endif
-                    </div>
-                    <div class="col-sm-6">
-                        {!! Form::label('ctr', 'Center Certification') !!}
+                    @else
+                        {!! Form::label('status', 'Status') !!}
+                        {!! Form::select('status', [
+                            1 => 'Active',
+                            0 => 'LOA'
+                        ], $user->status, ['class' => 'form-control', 'disabled']) !!}
+                    @endif
+                @endif
+                </div>
+                <div class="col-sm-6">
+                    {!! Form::label('ctr', 'Center Certification') !!}
+                    @if(Auth::user()->isAbleTo('roster') || Auth::user()->isAbleTo('train'))
                         {!! Form::select('ctr', [
                             0 => 'None',
                             99 => 'Solo Certification',
                             1 => 'Certified'
                         ], $user->ctr, ['class' => 'form-control']) !!}
-                    </div>
+                    @else
+                        {!! Form::select('ctr', [
+                            0 => 'None',
+                            99 => 'Solo Certification',
+                            1 => 'Certified'
+                        ], $user->ctr, ['class' => 'form-control', 'disabled']) !!}
+                    @endif
                 </div>
             </div>
-        @endif
-        @if(Auth::user()->isAbleTo('roster'))
-            <div class="form-group">
-                <div class="row">
+        </div>
+        <hr>
+        <div class="form-group">
+            <div class="row">
+                @if(Auth::user()->isAbleTo('roster'))
                     <div class="col-sm-6">
-                        @if($user->visitor == 1)
-                            {!! Form::label('status', 'Status') !!}
-                            {!! Form::select('status', [
-                                1 => 'Active',
-                                0 => 'LOA'
-                            ], $user->status, ['class' => 'form-control']) !!}
-                        @else
-                            {!! Form::label('staff', 'Staff Position') !!}
-                            {!! Form::select('staff', [
-                                0 => 'NONE',
-                                1 => 'ATM',
-                                2 => 'DATM',
-                                3 => 'TA',
-                                4 => 'ATA',
-                                5 => 'WM',
-                                6 => 'AWM',
-                                7 => 'FE',
-                                8 => 'AFE',
-                                9 => 'EC',
-                            ], $user->staff_position, ['class' => 'form-control']) !!}
-                        @endif
+                        {!! Form::label('staff', 'Staff Position') !!}
+                        {!! Form::select('staff', [
+                            0 => 'NONE',
+                            1 => 'ATM',
+                            2 => 'DATM',
+                            3 => 'TA',
+                            4 => 'ATA',
+                            5 => 'WM',
+                            6 => 'AWM',
+                            7 => 'FE',
+                            8 => 'AFE',
+                            9 => 'EC',
+                        ], $user->staff_position, ['class' => 'form-control']) !!}
+                    </div>
+                    <div class="col-sm-6">
+                        {!! Form::label('events_staff', 'Events Staff') !!}
+                        {!! Form::select('events_staff', [
+                            0 => 'NONE',
+                            1 => 'AEC',
+                            2 => 'AEC (Ghost)',
+                            3 => 'Events Team'
+                            ], $user->events_position, ['class' => 'form-control']) !!}
+                    </div>
+                @elseif(Auth::user()->isAbleTo('events'))
+                    <div class="col-sm-6">
+                        {!! Form::label('staff', 'Staff Position') !!}
+                        {!! Form::select('staff', [
+                            0 => 'NONE',
+                            1 => 'ATM',
+                            2 => 'DATM',
+                            3 => 'TA',
+                            4 => 'ATA',
+                            5 => 'WM',
+                            6 => 'AWM',
+                            7 => 'FE',
+                            8 => 'AFE',
+                            9 => 'EC',
+                        ], $user->staff_position, ['class' => 'form-control', 'disabled']) !!}
+                    </div>
+                    <div class="col-sm-6">
+                        {!! Form::label('events_staff', 'Events Staff') !!}
+                        {!! Form::select('events_staff', [
+                            0 => 'NONE',
+                            1 => 'AEC',
+                            2 => 'AEC (Ghost)',
+                            3 => 'Events Team'
+                            ], $user->events_position, ['class' => 'form-control']) !!}
+                    </div>
+                @else
+                    <div class="col-sm-6">
+                        {!! Form::label('staff', 'Staff Position') !!}
+                        {!! Form::select('staff', [
+                            0 => 'NONE',
+                            1 => 'ATM',
+                            2 => 'DATM',
+                            3 => 'TA',
+                            4 => 'ATA',
+                            5 => 'WM',
+                            6 => 'AWM',
+                            7 => 'FE',
+                            8 => 'AFE',
+                            9 => 'EC',
+                        ], $user->staff_position, ['class' => 'form-control', 'disabled']) !!}
+                    </div>
+                    <div class="col-sm-6">
+                        {!! Form::label('events_staff', 'Events Staff') !!}
+                        {!! Form::select('events_staff', [
+                            0 => 'NONE',
+                            1 => 'AEC',
+                            2 => 'AEC (Ghost)',
+                            3 => 'Events Team'
+                            ], $user->events_position, ['class' => 'form-control', 'disabled']) !!}
+                    </div>
+                @endif
+            </div>
+        </div>
+        <hr>
+        <div class="form-group">
+            <div class="row">
+                @if(Auth::user()->isAbleTo('roster'))
+                    <div class="col-sm-6">
+                        {!! Form::label('training', 'Training Position') !!}
+                        {!! Form::select('training', [
+                            0 => 'NONE',
+                            1 => 'MTR',
+                            2 => 'INS'
+                        ], $user->train_position, ['class' => 'form-control']) !!}
                     </div>
                     @if($user->hasRole('mtr') || $user->hasRole('ins'))
                         <div class="col-sm-6">
@@ -218,33 +301,14 @@ Update Controller
                             {!! Form::checkbox('max_minor_app', 1, true) !!}
                         </div>
                     @endif
-                </div>
-            </div>
-        @else
-            <div class="form-group">
-                <div class="row">
+                @else
                     <div class="col-sm-6">
-                        @if($user->visitor == 1)
-                            {!! Form::label('status', 'Status') !!}
-                            {!! Form::select('status', [
-                                1 => 'Active',
-                                0 => 'LOA'
-                            ], $user->status, ['class' => 'form-control', 'disabled']) !!}
-                        @else
-                            {!! Form::label('staff', 'Staff Position') !!}
-                            {!! Form::select('staff', [
-                                0 => 'NONE',
-                                1 => 'ATM',
-                                2 => 'DATM',
-                                3 => 'TA',
-                                4 => 'ATA',
-                                5 => 'WM',
-                                6 => 'AWM',
-                                7 => 'FE',
-                                8 => 'AFE',
-                                9 => 'EC',
-                            ], $user->staff_position, ['class' => 'form-control', 'disabled']) !!}
-                        @endif
+                        {!! Form::label('training', 'Training Position') !!}
+                        {!! Form::select('training', [
+                            0 => 'NONE',
+                            1 => 'MTR',
+                            2 => 'INS'
+                        ], $user->train_position, ['class' => 'form-control', 'disabled']) !!}
                     </div>
                     @if($user->hasRole('mtr') || $user->hasRole('ins'))
                         <div class="col-sm-6">
@@ -261,129 +325,10 @@ Update Controller
                             ], $user->max, ['class' => 'form-control', 'disabled']) !!}
                         </div>
                     @endif
-                </div>
+                @endif
             </div>
-        @endif
-        @if(Auth::user()->isAbleTo('roster'))
-            <div class="form-group">
-                <div class="row">
-                    <div class="col-sm-6">
-                        @if($user->visitor == 1)
-                            {!! Form::label('staff', 'Staff Position') !!}
-                            {!! Form::select('staff', [
-                                0 => 'NONE',
-                                1 => 'ATM',
-                                2 => 'DATM',
-                                3 => 'TA',
-                                4 => 'ATA',
-                                5 => 'WM',
-                                6 => 'AWM',
-                                7 => 'FE',
-                                8 => 'AFE',
-                                9 => 'EC',
-                            ], $user->staff_position, ['class' => 'form-control']) !!}
-                        @else
-                            {!! Form::label('training', 'Training Position') !!}
-                            {!! Form::select('training', [
-                                0 => 'NONE',
-                                1 => 'MTR',
-                                2 => 'INS'
-                            ], $user->train_position, ['class' => 'form-control']) !!}
-                        @endif
-                    </div>
-                </div>
-            </div>
-        @else
-            <div class="form-group">
-                <div class="row">
-                    <div class="col-sm-6">
-                        @if($user->visitor == 1)
-                            {!! Form::label('staff', 'Staff Position') !!}
-                            {!! Form::select('staff', [
-                                0 => 'NONE',
-                                1 => 'ATM',
-                                2 => 'DATM',
-                                3 => 'TA',
-                                4 => 'ATA',
-                                5 => 'WM',
-                                6 => 'AWM',
-                                7 => 'FE',
-                                8 => 'AFE',
-                                9 => 'EC',
-                            ], $user->staff_position, ['class' => 'form-control', 'disabled']) !!}
-                        @else
-                            {!! Form::label('training', 'Training Position') !!}
-                            {!! Form::select('training', [
-                                0 => 'NONE',
-                                1 => 'MTR',
-                                2 => 'INS'
-                            ], $user->train_position, ['class' => 'form-control', 'disabled']) !!}
-                        @endif
-                    </div>
-                </div>
-            </div>
-        @endif
-        @if(Auth::user()->isAbleTo('roster'))
-            <div class="form-group">
-                <div class="row">
-                    <div class="col-sm-6">
-                        @if($user->visitor == 1)
-                            {!! Form::label('training', 'Training Position') !!}
-                            {!! Form::select('training', [
-                                0 => 'NONE',
-                                1 => 'MTR',
-                                2 => 'INS'
-                            ], $user->train_position, ['class' => 'form-control']) !!}
-                        @endif
-                    </div>
-                    <div class="col-sm-6">
-                        {!! Form::label('events_staff', 'Events Staff') !!}
-                        {!! Form::select('events_staff', [
-                            0 => 'NONE',
-                            1 => 'AEC',
-                            2 => 'AEC (Ghost)',
-                            3 => 'Events Team'
-                            ], $user->events_position, ['class' => 'form-control']) !!}
-                    </div>
-                </div>
-            </div>
-        @else
-            <div class="form-group">
-                <div class="row">
-                    <div class="col-sm-6">
-                        @if($user->visitor == 1)
-                            {!! Form::label('training', 'Training Position') !!}
-                            {!! Form::select('training', [
-                                0 => 'NONE',
-                                1 => 'MTR',
-                                2 => 'INS'
-                            ], $user->train_position, ['class' => 'form-control', 'disabled']) !!}
-                        @endif
-                    </div>
-                    @if(Auth::user()->isAbleTo('events'))
-                    <div class="col-sm-6">
-                        {!! Form::label('events_staff', 'Events Staff') !!}
-                        {!! Form::select('events_staff', [
-                            0 => 'NONE',
-                            1 => 'AEC',
-                            2 => 'AEC (Ghost)',
-                            3 => 'Events Team'
-                            ], $user->events_position, ['class' => 'form-control']) !!}
-                    </div>
-                    @else
-                    <div class="col-sm-6">
-                        {!! Form::label('events_staff', 'Events Staff') !!}
-                        {!! Form::select('events_staff', [
-                            0 => 'NONE',
-                            1 => 'AEC',
-                            2 => 'AEC (Ghost)',
-                            3 => 'Events Team'
-                            ], $user->events_position, ['class' => 'form-control', 'disabled']) !!}
-                    </div>
-                    @endif
-                </div>
-            </div>
-        @endif
+        </div>
+        @if(Auth::user()->isAbleTo('roster') || Auth::user()->isAbleTo('train'))
             <div class="form-group">
                 <div class="row">
                     <div class="col-sm-6">
@@ -401,6 +346,8 @@ Update Controller
                     </div>
                 </div>
             </div>		
+        <hr>
+        @endif
         @if(Auth::user()->isAbleTo('roster'))
             <div class="form-group">
                 <div class="row">

--- a/resources/views/dashboard/controllers/roster.blade.php
+++ b/resources/views/dashboard/controllers/roster.blade.php
@@ -229,7 +229,7 @@
                     <tbody>
                     @foreach($vcontrollers as $c)
                         <tr>
-                            @if(Auth::user()->isAbleTo('roster') || Auth::user()->isAbleTo('train'))
+                            @if(Auth::user()->isAbleTo('roster') || Auth::user()->isAbleTo('train') || Auth::user()->isAbleTo('events'))
                                 <td><a href="/dashboard/admin/roster/edit/{{ $c->id }}">{{ $c->backwards_name }} - {{ $c->visitor_from }}</a></td>
                             @else
                                 <td>{{ $c->backwards_name }} - {{ $c->visitor_from }}</td>

--- a/resources/views/dashboard/controllers/roster.blade.php
+++ b/resources/views/dashboard/controllers/roster.blade.php
@@ -74,7 +74,7 @@
                     <tbody>
                     @foreach($hcontrollers as $c)
                         <tr>
-                            @if(Auth::user()->isAbleTo('roster') || Auth::user()->isAbleTo('train'))
+                            @if(Auth::user()->isAbleTo('roster') || Auth::user()->isAbleTo('train') || Auth::user()->isAbleTo('events'))
                                 <td><a href="/dashboard/admin/roster/edit/{{ $c->id }}">
                                         @if($c->hasRole('atm'))
                                             <span class="badge badge-danger">ATM</span> {{ $c->backwards_name }}
@@ -90,6 +90,8 @@
                                             <span class="badge badge-primary">EC</span> {{ $c->backwards_name }}
                                         @elseif($c->hasRole('aec'))
                                             <span class="badge badge-primary">AEC</span> {{ $c->backwards_name }}
+                                        @elseif($c->hasRole('aec-ghost'))
+                                            <span class="badge badge-primary">AEC-Ghost</span> {{ $c->backwards_name }}
                                         @elseif($c->hasRole('fe'))
                                             <span class="badge badge-primary">FE</span> {{ $c->backwards_name }}
                                         @elseif($c->hasRole('afe'))
@@ -100,6 +102,9 @@
                                             <span class="badge badge-info">MTR</span> {{ $c->backwards_name }}
                                         @else
                                             {{ $c->backwards_name }}
+                                        @endif
+                                        @if($c->hasRole('events-team'))
+                                            &nbsp;<span class="badge badge-warning">Events Team</span>
                                         @endif
                                     </a></td>
                             @else

--- a/resources/views/dashboard/controllers/roster.blade.php
+++ b/resources/views/dashboard/controllers/roster.blade.php
@@ -104,7 +104,7 @@
                                             {{ $c->backwards_name }}
                                         @endif
                                         @if($c->hasRole('events-team'))
-                                            &nbsp;<span class="badge badge-warning">Events Team</span>
+                                            <span class="badge badge-warning">Events Team</span>
                                         @endif
                                     </a></td>
                             @else

--- a/routes/web.php
+++ b/routes/web.php
@@ -213,7 +213,7 @@ Route::prefix('dashboard')->middleware('auth')->group(function () {
             Route::post('/visit-agreement/permit', 'AdminDash@allowVisitReq');
             Route::get('/purge-assistant/{year?}/{month?}', 'AdminDash@showRosterPurge');
         });
-        Route::prefix('roster')->middleware('permission:roster|train')->group(function () {
+        Route::prefix('roster')->middleware('permission:roster|train|events')->group(function () {
             Route::get('/edit/{id}', 'AdminDash@editController');
             Route::post('/edit/{id}', 'AdminDash@updateController');
         });


### PR DESCRIPTION
This PR will:
* Breaks out the events positions into a separate select menu in the roster edit view
* Gives the EC limited permissions to grant/revoke AEC, AEC-Ghost, and Events Team roles
* Adds special events team badges that are viewable only by staff on the roster list view
* Appropriate backend support added for the functions described above
* Close #311 
