### PR TITLE
NOISS: Sets tower solo fields input maxlength

### DIFF
--- a/resources/views/dashboard/admin/roster/edit.blade.php
+++ b/resources/views/dashboard/admin/roster/edit.blade.php
@@ -366,7 +366,7 @@ Update Controller
                 <div class="row">
                     <div class="col-sm-6">
 						{!! Form::label('twr_solo_fields', 'Class D Tower Solo Certifications') !!}
-						{!! Form::text('twr_solo_fields', $user->twr_solo_fields, ['class' => 'form-control']) !!}    
+						{!! Form::text('twr_solo_fields', $user->twr_solo_fields, ['class' => 'form-control','maxlength' => 255]) !!}
                     </div>
                     <div class="col-sm-6">
                     {!! Form::label('twr_solo_expires', 'Tower Solo Expiration Date', ['class' => 'form-label']) !!}


### PR DESCRIPTION
This PR will:
* Resolves a bug pointed out by training staff where length inputs in the tower solo fields roster edit form can exceed the database column size and throw an error. Sets maxlength of input field to 255, matching VARCHAR database column.