### PR TITLE
#325 Add link to teamspeak policy on teamspeak info page

### DIFF
--- a/resources/views/site/teamspeak.blade.php
+++ b/resources/views/site/teamspeak.blade.php
@@ -34,6 +34,7 @@ Teamspeak
                 <li>Controlling rooms are limited to controlling only. If a controller asks for you to leave, please do so.</li>
                 <li>Use of the teamspeak is a privilage and can be revoked by a staff member at any time and for any reason. To appeal teamspeak bans, please contact the DATM at <a href="datm@ztlartcc.org">datm@ztlartcc.org</a>.</li>
             </ul>
+            <p>Please review the <a href="https://www.ztlartcc.org/asset/TeamSpeakDiscordPolicy">TeamSpeak and Discord Policy</a> for the full list of rules prior to joining the TeamSpeak server.</p>
         </div>
         <div class="col-sm-2">
         </div>


### PR DESCRIPTION
This PR will:
* Add a link on the Teamspeak info page prompting to review the full Teamspeak and discord policy, linking to the permalink
* Close #325 
