### PR TITLE
#324 add a long-form remarks input to event signups

### DIFF
--- a/app/Http/Controllers/ControllerDash.php
+++ b/app/Http/Controllers/ControllerDash.php
@@ -402,6 +402,7 @@ class ControllerDash extends Controller {
                 $reg->end_time = $request->end_time1;
                 $reg->status = 0;
                 $reg->choice_number = 1;
+                $reg->remarks = $request->remarks;
                 $reg->save();
             } else {
                 $reg = new EventRegistration;
@@ -412,6 +413,7 @@ class ControllerDash extends Controller {
                 $reg->end_time = $request->end_time1;
                 $reg->status = 0;
                 $reg->choice_number = 1;
+                $reg->remarks = $request->remarks;
                 $reg->save();
             }
         } else {

--- a/database/migrations/2023_08_20_014254_update_event_registration_add_remarks.php
+++ b/database/migrations/2023_08_20_014254_update_event_registration_add_remarks.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up() {
+        Schema::table('event_registration', function ($table) {
+            $table->string('remarks', 1024)->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down() {
+        Schema::table('event_registration', function ($table) {
+            $table->dropColumn('remarks');
+        });
+    }
+};

--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -158,3 +158,7 @@ body {
 .home-modal-bg {
   background: silver !important;
 }
+
+.textarea-no-resize {
+  resize: none;
+}

--- a/resources/views/dashboard/controllers/events/view.blade.php
+++ b/resources/views/dashboard/controllers/events/view.blade.php
@@ -60,7 +60,7 @@ View Event
                                 <th scope="col">Controller</th>
                                 <th scope="col">Availability</th>
                                 @if(Auth::user()->isAbleTo('events'))
-                                <th scope="col">Actions   </th>
+                                <th scope="col">Actions</th>
                                 @endif
                             </tr>
                             </thead>
@@ -93,9 +93,10 @@ View Event
                                                     <button data-toggle="modal" data-target="#addrequest{{ $r->id }}" type="button" class="btn btn-success btn-sm simple-tooltip" data-placement="top" title="Assign Position">
                                                         <i class="fas fa-check fa-fw"></i>
                                                     </button>
-                                                    <button onclick="window.location.href='/dashboard/controllers/events/view/{{ $r->id }}/un-signup'" class="btn btn-danger btn-sm simple-tooltip" title="Delete Request">
+
+                                                    <a href="/dashboard/controllers/events/view/{{ $r->id }}/un-signup" class="btn btn-danger btn-sm" title="Delete Request">
                                                         <i class="fas fa-trash fa-fw"></i>
-                                                    </button>
+                                                    </a>
 
                                                     @if($r->remarks != null)
                                                         <button data-toggle="modal" data-target="#remarks{{ $r->id }}" type="button" class="btn btn-info btn-sm simple-tooltip" data-placement="top" title="View Remarks">

--- a/resources/views/dashboard/controllers/events/view.blade.php
+++ b/resources/views/dashboard/controllers/events/view.blade.php
@@ -60,7 +60,7 @@ View Event
                                 <th scope="col">Controller</th>
                                 <th scope="col">Availability</th>
                                 @if(Auth::user()->isAbleTo('events'))
-                                <th scope="col">Actions</th>
+                                <th scope="col">Actions   </th>
                                 @endif
                             </tr>
                             </thead>
@@ -87,14 +87,50 @@ View Event
                                         </td>
                                         @if(Auth::user()->isAbleTo('events'))
                                             <td>
-                                                <span data-toggle="modal" data-target="#addrequest{{ $r->id }}">
-                                                    <button type="button" class="btn btn-success btn-sm simple-tooltip" data-placement="top" data-toggle="tooltip" title="Assign Position"><i class="fas fa-check"></i></button>
-                                                </span>
-                                                &nbsp;
-                                                <a href="/dashboard/controllers/events/view/{{ $r->id }}/un-signup" class="btn btn-danger btn-sm simple-tooltip" data-toggle="tooltip" title="Delete Request"><i class="fas fa-times"></i></a>
+
+                                                <div class="btn-group" role="group" aria-label="Actions">
+
+                                                    <button data-toggle="modal" data-target="#addrequest{{ $r->id }}" type="button" class="btn btn-success btn-sm simple-tooltip" data-placement="top" title="Assign Position">
+                                                        <i class="fas fa-check fa-fw"></i>
+                                                    </button>
+                                                    <button onclick="window.location.href='/dashboard/controllers/events/view/{{ $r->id }}/un-signup'" class="btn btn-danger btn-sm simple-tooltip" title="Delete Request">
+                                                        <i class="fas fa-trash fa-fw"></i>
+                                                    </button>
+
+                                                    @if($r->remarks != null)
+                                                        <button data-toggle="modal" data-target="#remarks{{ $r->id }}" type="button" class="btn btn-info btn-sm simple-tooltip" data-placement="top" title="View Remarks">
+                                                            <i class="fas fa-info-circle fa-fw"></i>
+                                                        </button>
+                                                    @else
+                                                        <button disabled data-toggle="modal" data-target="#remarks{{ $r->id }}" type="button" class="btn btn-info btn-sm disabled" data-placement="top" title="No Remarks Provided">
+                                                            <i class="fas fa-info-circle fa-fw"></i>
+                                                        </button>
+                                                    @endif
+                                                </div>
                                             </td>
                                         @endif
                                     </tr>
+
+                                    <div class="modal fade" id="remarks{{ $r->id }}" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
+                                        <div class="modal-dialog" role="document">
+                                            <div class="modal-content">
+                                                <div class="modal-header">
+                                                    <h5 class="modal-title">Position Remarks</h5>
+                                                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                                                        <span aria-hidden="true">&times;</span>
+                                                    </button>
+                                                </div>
+                                                <div class="modal-body">
+                                                    <p><i>Remarks submitted by {{ $r->controller_name }}:</i></p>
+                                                    <p>{{ $r->remarks }}</p>
+                                                </div>
+                                                <div class="modal-footer">
+                                                    <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+                                                </div>
+
+                                            </div>
+                                        </div>
+                                    </div>
 
                                     <div class="modal fade" id="addrequest{{ $r->id }}" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
                                         <div class="modal-dialog" role="document">
@@ -294,6 +330,11 @@ View Event
                                             </div>
                                             <div class="col-sm-3">
                                                 {!! Form::text('end_time1', null, ['placeholder' => $event->end_time, 'class' => 'form-control']) !!}
+                                            </div>
+                                        </div>
+                                        <div class="row pt-2">
+                                            <div class="col-sm-11">
+                                                {!! Form::textarea('remarks', null, ['placeholder' => 'Enter any relevant remarks here...', 'class' => 'form-control textarea-no-resize']) !!}
                                             </div>
                                         </div>
                                     @endif

--- a/resources/views/dashboard/controllers/events/view.blade.php
+++ b/resources/views/dashboard/controllers/events/view.blade.php
@@ -335,7 +335,7 @@ View Event
                                         </div>
                                         <div class="row pt-2">
                                             <div class="col-sm-11">
-                                                {!! Form::textarea('remarks', null, ['placeholder' => 'Enter any relevant remarks here...', 'class' => 'form-control textarea-no-resize']) !!}
+                                                {!! Form::textarea('remarks', null, ['placeholder' => 'Specific position requests/additional information', 'class' => 'form-control textarea-no-resize', 'rows' => '3', 'maxlength' => '1024']) !!}
                                             </div>
                                         </div>
                                     @endif


### PR DESCRIPTION
This PR will:
* Add long-form remarks input to event signups to allow controllers to attach additional pertinent info to their signup request
* Convert the buttons on the positions request list to a button group so it looks cleaner
* Add an extra button to the button group to show a popup containing remarks attached to that request, if any
* Close #324 
