### PR TITLE
#345 Move broadcast email toggle to profile, out of dashboard header

### DIFF
--- a/resources/views/dashboard/controllers/profile.blade.php
+++ b/resources/views/dashboard/controllers/profile.blade.php
@@ -156,6 +156,24 @@ Profile
                     </div>
                 </div>
                 {!! Form::close() !!}
+
+                Receive Broadcast Emails?
+                &nbsp;
+                @if(Auth::user()->opt == 1)
+                   <span data-toggle="modal" data-target="#unOpt">
+                          <label class="switch">
+                              <input type="checkbox" checked>
+                            <span class="slider round"></span>
+                            </label>
+                        </span>
+               @else
+                   <span data-toggle="modal" data-target="#Opt">
+                        <label class="switch">
+                            <input type="checkbox">
+                            <span class="slider round"></span>
+                        </label>
+                    </span>
+            @endif
         </div>
         <div class="col-sm-2">
         </div>
@@ -203,4 +221,54 @@ Profile
         </div>
     </div>
 </div>
+
+<div class="modal fade" id="unOpt" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Opt Out of Broadcast Emails?</h5>
+            </div>
+            <br>
+            <div class="container">
+                <p>Please note that opting out of broadcast emails will only prevent you from receiving broadcast emails issued from staff. Personalized emails (both automated and issued by staff) will not be affected. If you have any questions, please contact the ATM at <a href="mailto:atm@ztlartcc.org">atm@ztlartcc.org</a>.</p>
+            </div>
+            <div class="modal-footer">
+                <a href="{{ url()->current() }}" class="btn btn-secondary">Close</a>
+                <a href="/dashboard/opt/out" class="btn btn-success">Confirm Selection</a>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="Opt" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Opt Into Broadcast Emails?</h5>
+            </div>
+            <br>
+            <div class="container">
+                <p>Opting into emails will only affect the recieving of mass emails. If you elect to opt into emails, you agree to recieve mass emails sent to groups of members of the vZTL ARTCC. This selection will not affect the reception of personalized emails (both automated and issued by staff) for example, training ticket emails. If you have any questions, please contact the ATM at <a href="mailto:atm@ztlartcc.org">atm@ztlartcc.org</a>.</p>
+                <p>You may opt out at any time by using the slider shown at the top of the controller dashboard at all times.</p>
+                <br>
+                <i>Please check the following check boxes if you would like to continue.</i>
+                <hr>
+                {!! Form::open(['action' => 'ControllerDash@optIn']) !!}
+                <div class="form-group">
+                    {!! Form::checkbox('opt', '1', false) !!}
+                    {!! Form::label('opt', 'I agree to recieve mass emails from the vZTL ARTCC.', ['class' => 'form-label']) !!}
+                    <br>
+                    {!! Form::checkbox('privacy', '1', false) !!}
+                    {!! Form::label('privacy', 'I have read and agree to the vZTL ARTCC Privacy Policy.', ['class' => 'form-label']) !!}
+                </div>
+            </div>
+            <div class="modal-footer">
+                <a href="{{ url()->current() }}" class="btn btn-secondary">Close</a>
+                <button type="submit" class="btn btn-success">Confirm Selection</button>
+                {!! Form::close() !!}
+            </div>
+        </div>
+    </div>
+</div>
+
 @endsection

--- a/resources/views/inc/dashboard-head.blade.php
+++ b/resources/views/inc/dashboard-head.blade.php
@@ -38,26 +38,7 @@
                 {!! Form::close() !!}
             </ul>
             &nbsp;&nbsp;&nbsp;
-            <ul>
-                <br />
-                Receive Broadcast Emails?
-                &nbsp;
-                @if(Auth::user()->opt == 1)
-                    <span data-toggle="modal" data-target="#unOpt">
-                        <label class="switch">
-                            <input type="checkbox" checked>
-                            <span class="slider round"></span>
-                        </label>
-                    </span>
-                @else
-                    <span data-toggle="modal" data-target="#Opt">
-                        <label class="switch">
-                            <input type="checkbox">
-                            <span class="slider round"></span>
-                        </label>
-                    </span>
-                @endif
-            </ul>
+
             <ul class="navbar-nav ml-auto">
 			<a class="nav-link {{ Nav::isRoute('controller_dash_home') }}" href="/dashboard">Dashboard Home</a>
                 <li class="nav-item dropdown">
@@ -68,54 +49,7 @@
     </nav>
 </div>
 
-<div class="modal fade" id="unOpt" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
-    <div class="modal-dialog" role="document">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title">Opt Out of Broadcast Emails?</h5>
-            </div>
-            <br>
-            <div class="container">
-                <p>Please note that opting out of broadcast emails will only prevent you from receiving broadcast emails issued from staff. Personalized emails (both automated and issued by staff) will not be affected. If you have any questions, please contact the ATM at <a href="mailto:atm@ztlartcc.org">atm@ztlartcc.org</a>.</p>
-            </div>
-            <div class="modal-footer">
-                <a href="{{ url()->current() }}" class="btn btn-secondary">Close</a>
-                <a href="/dashboard/opt/out" class="btn btn-success">Confirm Selection</a>
-            </div>
-        </div>
-    </div>
-</div>
 
-<div class="modal fade" id="Opt" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
-    <div class="modal-dialog" role="document">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title">Opt Into Broadcast Emails?</h5>
-            </div>
-            <br>
-            <div class="container">
-                <p>Opting into emails will only affect the recieving of mass emails. If you elect to opt into emails, you agree to recieve mass emails sent to groups of members of the vZTL ARTCC. This selection will not affect the reception of personalized emails (both automated and issued by staff) for example, training ticket emails. If you have any questions, please contact the ATM at <a href="mailto:atm@ztlartcc.org">atm@ztlartcc.org</a>.</p>
-                <p>You may opt out at any time by using the slider shown at the top of the controller dashboard at all times.</p>
-                <br>
-                <i>Please check the following check boxes if you would like to continue.</i>
-                <hr>
-                {!! Form::open(['action' => 'ControllerDash@optIn']) !!}
-                    <div class="form-group">
-                        {!! Form::checkbox('opt', '1', false) !!}
-                        {!! Form::label('opt', 'I agree to recieve mass emails from the vZTL ARTCC.', ['class' => 'form-label']) !!}
-                        <br>
-                        {!! Form::checkbox('privacy', '1', false) !!}
-                        {!! Form::label('privacy', 'I have read and agree to the vZTL ARTCC Privacy Policy.', ['class' => 'form-label']) !!}
-                    </div>
-            </div>
-            <div class="modal-footer">
-                <a href="{{ url()->current() }}" class="btn btn-secondary">Close</a>
-                <button type="submit" class="btn btn-success">Confirm Selection</button>
-                {!! Form::close() !!}
-            </div>
-        </div>
-    </div>
-</div>
 
 <style>
 .switch {


### PR DESCRIPTION
This PR will:
* Move the broadcast email toggle to the profile page, and out of the dashboard header
* Close #345 
