### PR TITLE
#351 Automate support events

### DIFF
--- a/app/Console/Commands/SupportEvents.php
+++ b/app/Console/Commands/SupportEvents.php
@@ -32,9 +32,25 @@ class SupportEvents extends Command {
         parent::__construct();
     }
 
-    protected array $pull_events_for = [
-        'all_events' => ['KZID', 'KZDC', 'KZJX', 'KZHU', 'KZME'],
-        'fno_or_live_only' => ['KZMA', 'KZNY']
+    protected array $event_pull_lut = [
+        'all_events' => [
+            // KZID
+            'KZID' => ['KAAS', 'KAID', 'KAJG', 'KAMT', 'KAOH', 'KAXV', 'KBAK', 'KBFR', 'KBKW', 'KBLF', 'KBMG', 'KBRY', 'KBYL', 'KCEV', 'KCFJ', 'KCMH', 'KCPF', 'KCQA', 'KCRW', 'KCUL', 'KCVG', 'KCYO', 'KDAY', 'KDCY', 'KDLZ', 'KDVK', 'KDWU', 'KEBD', 'KEDJ', 'KEHR', 'KEKQ', 'KEKX', 'KEOP', 'KEVV', 'KEYE', 'KFFO', 'KFFT', 'KFGX', 'KFRH', 'KFTK', 'KGAS', 'KGEO', 'KGEZ', 'KGFD', 'KGPC', 'KHAO', 'KHBE', 'KHFY', 'KHLB', 'KHNB', 'KHOC', 'KHTS', 'KHTW', 'KHUF', 'KILN', 'KIMS', 'KIND', 'KIOB', 'KJKL', 'KJQD', 'KJVY', 'KLCK', 'KLEX', 'KLHQ', 'KLNP', 'KLOU', 'KLOZ', 'KLSD', 'KLUK', 'KLWV', 'KMGY', 'KMIE', 'KMQJ', 'KMRT', 'KMWO', 'KOSU', 'KOVO', 'KOWB', 'KOXD', 'KPBX', 'KPKB', 'KPLD', 'KPMH', 'KPRG', 'KRGA', 'KRID', 'KRLX', 'KRSV', 'KRZT', 'KSCA', 'KSCX', 'KSDF', 'KSER', 'KSGH', 'KSIV', 'KSJS', 'KSME', 'KSXL', 'KSYM', 'KTEL', 'KTZR', 'KUMP', 'KUNI', 'KUSW', 'KUWL', 'KUYF', 'KVES', 'KVNW', 'KVTA', 'KZZV'],
+            // KZDC
+            'KZDC' => ['KACY', 'KACZ', 'KADW', 'KAKQ', 'KANP', 'KAPG', 'KAPH', 'KASJ', 'KAVC', 'KBCB', 'KBKT', 'KBUY', 'KBWI', 'KCGE', 'KCGS', 'KCHO', 'KCJR', 'KCPK', 'KCTZ', 'KCXE', 'KDAA', 'KDAN', 'KDCA', 'KDCA', 'KDCA', 'KDCA', 'KDOV', 'KDPL', 'KECG', 'KEDE', 'KEKN', 'KEMV', 'KESN', 'KETC', 'KEWN', 'KEYF', 'KEZF', 'KFAF', 'KFAY', 'KFBG', 'KFCI', 'KFDK', 'KFFA', 'KFKN', 'KFME', 'KFRR', 'KFVX', 'KFYJ', 'KGAI', 'KGED', 'KGSB', 'KGVE', 'KGWW', 'KHAT', 'KHEF', 'KHFF', 'KHGR', 'KHNZ', 'KHRJ', 'KHSE', 'KHSP', 'KHWY', 'KIAD', 'KIGX', 'KILM', 'KISO', 'KIXA', 'KJGG', 'KJNX', 'KJWX', 'KJYO', 'KLBT', 'KLFI', 'KLHZ', 'KLKU', 'KLUA', 'KLVL', 'KLWB', 'KLYH', 'KMCZ', 'KMEB', 'KMFV', 'KMHX', 'KMIV', 'KMQI', 'KMRB', 'KMRH', 'KMTN', 'KMTV', 'KNAK', 'KNCA', 'KNDY', 'KNFE', 'KNGU', 'KNHK', 'KNIS', 'KNJM', 'KNKT', 'KNLT', 'KNTU', 'KNUI', 'KNYG', 'KOAJ', 'KOBI', 'KOCW', 'KOFP', 'KOKV', 'KOMH', 'KONX', 'KORF', 'KOXB', 'KPGV', 'KPHF', 'KPMZ', 'KPOB', 'KPTB', 'KPVG', 'KRCZ', 'KRDU', 'KRIC', 'KRJD', 'KRMN', 'KROA', 'KRWI', 'KRZZ', 'KSBY', 'KSCR', 'KSFQ', 'KSHD', 'KSIF', 'KSOP', 'KSSU', 'KTDF', 'KTGI', 'KTTA', 'KVBW', 'KVKX', 'KVQN', 'KWAL', 'KWWD', 'KXSA'],
+            // KZJX
+            'KZJX' => ['KAAF', 'KABY', 'KAIK', 'KAMG', 'KAQQ', 'KAQX', 'KARW', 'KAYS', 'KAZE', 'KBBP', 'KBGE', 'KBHC', 'KBIJ', 'KBKV', 'KBNL', 'KBQK', 'KCAE', 'KCDK', 'KCDN', 'KCEW', 'KCGC', 'KCHS', 'KCKF', 'KCKI', 'KCLW', 'KCOF', 'KCPC', 'KCQF', 'KCQW', 'KCRE', 'KCRG', 'KCTY', 'KCUB', 'KCWV', 'KCXU', 'KDAB', 'KDED', 'KDHN', 'KDLC', 'KDQH', 'KDTS', 'KDYB', 'KECP', 'KEDN', 'KEGI', 'KEVB', 'KEZM', 'KFDW', 'KFHB', 'KFIN', 'KFLO', 'KFZG', 'KGGE', 'KGNV', 'KGZH', 'KHEG', 'KHEY', 'KHOE', 'KHRT', 'KHVS', 'KHXD', 'KHYW', 'KIGC', 'KINF', 'KISM', 'KJAX', 'KJES', 'KJKA', 'KJYL', 'KJZI', 'KLCQ', 'KLEE', 'KLHW', 'KLOR', 'KLRO', 'KMAI', 'KMAO', 'KMCO', 'KMGR', 'KMHP', 'KMKS', 'KMLB', 'KMMT', 'KMNI', 'KMQW', 'KMUL', 'KMYR', 'KNAE', 'KNBC', 'KNBJ', 'KNBQ', 'KNDZ', 'KNEN', 'KNEX', 'KNFD', 'KNFJ', 'KNGS', 'KNIP', 'KNPA', 'KNRB', 'KNRQ', 'KNSE', 'KNZC', 'KOCF', 'KOGB', 'KOMN', 'KORL', 'KOZR', 'KPAM', 'KPHH', 'KPNS', 'KPYG', 'KRBW', 'KRRF', 'KRVJ', 'KSAV', 'KSFB', 'KSGJ', 'KSMS', 'KSSC', 'KSSI', 'KSUT', 'KSVN', 'KSYV', 'KTBR', 'KTIX', 'KTLH', 'KTMA', 'KTTS', 'KTVI', 'KUDG', 'KVAD', 'KVDF', 'KVDI', 'KVLD', 'KVPS', 'KVQQ', 'KXNO', 'KZPH'],
+            // KZHU
+            'KZHU' => ['KACP', 'KAEX', 'KALI', 'KAPS', 'KAPY', 'KAQO', 'KARA', 'KARM', 'KASD', 'KAUS', 'KAXH', 'KBAZ', 'KBBD', 'KBCG', 'KBEA', 'KBFM', 'KBIX', 'KBKS', 'KBMQ', 'KBMT', 'KBPT', 'KBRO', 'KBTR', 'KBVE', 'KBXA', 'KBYY', 'KCFD', 'KCLL', 'KCOT', 'KCRP', 'KCVB', 'KCWF', 'KCXO', 'KCZT', 'KDKR', 'KDLF', 'KDRI', 'KDRT', 'KDWH', 'KDZB', 'KEBG', 'KECU', 'KEDC', 'KEFD', 'KELA', 'KERV', 'KESF', 'KEYQ', 'KGAO', 'KGLS', 'KGNI', 'KGPT', 'KGRK', 'KGTU', 'KGYB', 'KHBG', 'KHBV', 'KHDC', 'KHDO', 'KHEZ', 'KHLR', 'KHOU', 'KHPY', 'KHRL', 'KHRL', 'KHSA', 'KHUM', 'KHYI', 'KHZR', 'KIAH', 'KIAH', 'KIKG', 'KILE', 'KIWS', 'KIYA', 'KJAS', 'KJCT', 'KLBX', 'KLCH', 'KLFK', 'KLFT', 'KLHB', 'KLIX', 'KLRD', 'KLVJ', 'KLZZ', 'KMCB', 'KMFE', 'KMJD', 'KMKV', 'KMOB', 'KMSY', 'KNBG', 'KNEW', 'KNGP', 'KNGT', 'KNGW', 'KNMT', 'KNOG', 'KNQI', 'KNVT', 'KNWL', 'KOPL', 'KORG', 'KOZA', 'KPCU', 'KPEZ', 'KPGL', 'KPIB', 'KPIL', 'KPKV', 'KPOE', 'KPQL', 'KPSX', 'KPTN', 'KRAS', 'KRBO', 'KRCK', 'KREG', 'KRFG', 'KRKP', 'KRND', 'KRPE', 'KRWV', 'KRYW', 'KSAT', 'KSEQ', 'KSGR', 'KSKF', 'KSLJ', 'KSOA', 'KSSF', 'KTFP', 'KTME', 'KTPL', 'KTXW', 'KUTS', 'KUVA', 'KUXL', 'KVCT', 'KVRX', 'KVUW'],
+            // KZME
+            'KZME' => ['KADF', 'KAIV', 'KAPT', 'KARG', 'KASG', 'KAWM', 'KAYX', 'KAZU', 'KBBG', 'KBDQ', 'KBGF', 'KBNA', 'KBPK', 'KBVX', 'KBWG', 'KBYH', 'KCBM', 'KCCA', 'KCEY', 'KCGI', 'KCHQ', 'KCIR', 'KCKM', 'KCKV', 'KCMD', 'KCRT', 'KCRX', 'KCVK', 'KCXW', 'KDRP', 'KDXE', 'KDYR', 'KEIW', 'KEOD', 'KFCY', 'KFLP', 'KFSM', 'KFSM', 'KFYE', 'KFYM', 'KFYV', 'KGHM', 'KGLH', 'KGLW', 'KGNF', 'KGTR', 'KGWO', 'KGZS', 'KHAB', 'KHBZ', 'KHEE', 'KHKA', 'KHKS', 'KHOP', 'KHOT', 'KHRO', 'KHUA', 'KHVC', 'KHZD', 'KIDL', 'KJAN', 'KJBR', 'KJSV', 'KJVW', 'KJWN', 'KLIT', 'KLLQ', 'KLMS', 'KLRF', 'KLUG', 'KLUL', 'KLZK', 'KMAW', 'KMBO', 'KMBT', 'KMDQ', 'KMEI', 'KMEM', 'KMEZ', 'KMKL', 'KMMS', 'KMPE', 'KMPJ', 'KMQY', 'KMRC', 'KMSL', 'KMXA', 'KNJW', 'KNMM', 'KNQA', 'KOLV', 'KORK', 'KOSX', 'KPAH', 'KPBF', 'KPGR', 'KPHT', 'KPLK', 'KPMU', 'KPOF', 'KPVE', 'KPYN', 'KRBM', 'KRKR', 'KRNC', 'KRNV', 'KROG', 'KRUE', 'KSGT', 'KSIK', 'KSLG', 'KSNH', 'KSRB', 'KSRC', 'KSTF', 'KSUZ', 'KSYI', 'KSZY', 'KTGC', 'KTHA', 'KTKX', 'KTQH', 'KTUP', 'KTVR', 'KTWT', 'KTZV', 'KUBS', 'KUCY', 'KUNO', 'KUOS', 'KUOX', 'KUTA', 'KVBT', 'KVKS', 'KXNA', 'KXNX']
+        ],
+        'fno_or_live_only' => [
+            // KZMA
+            'KZMA' => ['KAGR', 'KAPF', 'KAVO', 'KBCT', 'KBOW', 'KCHN', 'KCOI', 'KEYW', 'KFLL', 'KFMY', 'KFPR', 'KFXE', 'KGIF', 'KHST', 'KHWO', 'KIMM', 'KLAL', 'KLNA', 'KMCF', 'KMIA', 'KMKY', 'KMTH', 'KNQX', 'KOBE', 'KOPF', 'KPBI', 'KPCM', 'KPGD', 'KPHK', 'KPIE', 'KPMP', 'KRSW', 'KSEF', 'KSPG', 'KSRQ', 'KSUA', 'KTBW', 'KTMB', 'KTNT', 'KTPA', 'KTPF', 'KVNC', 'KVRB', 'KXMR', 'MBAC', 'MBNC', 'MBPI', 'MBSC', 'MBSY'],
+            // KZNY
+            'KZNY' => ['KABE', 'KAVP', 'KBDR', 'KBGM', 'KBLM', 'KCDW', 'KCKZ', 'KCTO', 'KCXY', 'KCZG', 'KDMW', 'KDXR', 'KDYL', 'KELM', 'KEVY', 'KEWR', 'KFOK', 'KFRG', 'KFWN', 'KHPN', 'KHTO', 'KHVN', 'KHWV', 'KHZL', 'KILG', 'KIPT', 'KISP', 'KJFK', 'KJRB', 'KLDJ', 'KLGA', 'KLHV', 'KLNS', 'KLOM', 'KMDT', 'KMGJ', 'KMJX', 'KMMU', 'KMPO', 'KMQS', 'KMUI', 'KNEL', 'KOQN', 'KOXC', 'KPHL', 'KPNE', 'KPOU', 'KPSB', 'KPTW', 'KRDG', 'KRVL', 'KSEG', 'KSMQ', 'KSWF', 'KTEB', 'KTHV', 'KTTN', 'KUKT', 'KUNV', 'KVAY', 'KWBW', 'KWRI', 'KXLL', 'KZER']
+        ]
     ];
 
     /**
@@ -44,6 +60,26 @@ class SupportEvents extends Command {
      */
     public function handle() {
         $this->info("-- Updating support events - this may take a while --");
+
+        $this->info("Building ARTCC LUTs");
+
+        $all_events_lut = [];
+        $fno_or_live_only_lut = [];
+        $inverse_lut = [];
+
+        foreach ($this->event_pull_lut["all_events"] as $artcc => $airports) {
+            foreach ($airports as $airport) {
+                $all_events_lut[] = $airport;
+                $inverse_lut[$airport] = $artcc;
+            }
+        }
+        foreach ($this->event_pull_lut["fno_or_live_only"] as $artcc => $airports) {
+            foreach ($airports as $airport) {
+                $fno_or_live_only_lut[] = $airport;
+                $inverse_lut[$airport] = $artcc;
+            }
+        }
+
 
         $client = new Client();
 
@@ -72,25 +108,25 @@ class SupportEvents extends Command {
             $start_time = Carbon::parse($event->start_time);
             $end_time = Carbon::parse($event->end_time);
 
-            foreach ($event->organisers as $o) {
-                if (in_array($o->region, $this->pull_events_for['all_events'])) {
+            foreach ($event->airports as $airport) {
+                if (in_array($airport->icao, $all_events_lut)) {
                     $pull_this_event = true;
-                    $organizer = substr($o->region, 1);
+                    $organizer = $inverse_lut[$airport->icao];
                     break;
                 }
-                if (in_array($o->region, $this->pull_events_for['fno_or_live_only'])) {
+                if (in_array($airport->icao, $fno_or_live_only_lut)) {
                     // is it a live event?
                     if (str_contains(strtolower($event->name), 'live')) {
                         // live event - pull this event too
                         $pull_this_event = true;
-                        $organizer = substr($o->region, 1);
+                        $organizer = $inverse_lut[$airport->icao];
                         break;
                     }
                     // is it on a friday? (FNO)
                     if ($start_time->dayOfWeek == 6) { // 06: Friday
                         // FNO - pull this event too
                         $pull_this_event = true;
-                        $organizer = substr($o->region, 1);
+                        $organizer = $inverse_lut[$airport->icao];
                         break;
                     }
                 }

--- a/app/Console/Commands/SupportEvents.php
+++ b/app/Console/Commands/SupportEvents.php
@@ -155,14 +155,14 @@ class SupportEvents extends Command {
             $our_event->name = $event->name;
             $our_event->host = $organizer;
             $our_event->description = $event->description;
-            $our_event->date = $start_time->toDate();
+            $our_event->date = $start_time->format("m/d/Y");
             $our_event->start_time = $start_time->toTimeString('minute');
             $our_event->end_time = $end_time->toTimeString('minute');
 
             $our_event->banner_path = $public_url;
             $our_event->reduceEventBanner();
 
-            $our_event->banner_path = '/storage/'.$public_url; // TODO, we need to download this
+            $our_event->banner_path = '/storage/'.$public_url;
             $our_event->status = 0;
             $our_event->reg = 0;
             $our_event->type = 2; // auto - unverified

--- a/app/Console/Commands/SupportEvents.php
+++ b/app/Console/Commands/SupportEvents.php
@@ -122,7 +122,11 @@ class SupportEvents extends Command {
             $our_event->date = $start_time->toDate();
             $our_event->start_time = $start_time->toTimeString('minute');
             $our_event->end_time = $end_time->toTimeString('minute');
-            $our_event->banner_path = $public_url; // TODO, we need to download this
+
+            $our_event->banner_path = $public_url;
+            $our_event->reduceEventBanner();
+
+            $our_event->banner_path = '/storage/'.$public_url; // TODO, we need to download this
             $our_event->status = 0;
             $our_event->reg = 0;
             $our_event->type = 2; // auto - unverified

--- a/app/Console/Commands/SupportEvents.php
+++ b/app/Console/Commands/SupportEvents.php
@@ -3,6 +3,7 @@
 namespace App\Console\Commands;
 
 use App\Event;
+use App\EventPosition;
 use Carbon\Carbon;
 use GuzzleHttp\Client;
 use Illuminate\Console\Command;
@@ -51,6 +52,18 @@ class SupportEvents extends Command {
             // KZNY
             'KZNY' => ['KABE', 'KAVP', 'KBDR', 'KBGM', 'KBLM', 'KCDW', 'KCKZ', 'KCTO', 'KCXY', 'KCZG', 'KDMW', 'KDXR', 'KDYL', 'KELM', 'KEVY', 'KEWR', 'KFOK', 'KFRG', 'KFWN', 'KHPN', 'KHTO', 'KHVN', 'KHWV', 'KHZL', 'KILG', 'KIPT', 'KISP', 'KJFK', 'KJRB', 'KLDJ', 'KLGA', 'KLHV', 'KLNS', 'KLOM', 'KMDT', 'KMGJ', 'KMJX', 'KMMU', 'KMPO', 'KMQS', 'KMUI', 'KNEL', 'KOQN', 'KOXC', 'KPHL', 'KPNE', 'KPOU', 'KPSB', 'KPTW', 'KRDG', 'KRVL', 'KSEG', 'KSMQ', 'KSWF', 'KTEB', 'KTHV', 'KTTN', 'KUKT', 'KUNV', 'KVAY', 'KWBW', 'KWRI', 'KXLL', 'KZER']
         ]
+    ];
+
+    protected array $event_position_preset = [
+        "STBY | Standby",
+        "ZTL | Atlanta Center",
+        "A80 | Sattelite ATCT",
+        "A80 | Atlanta TRACON",
+        "ATL | Atlanta ATCT",
+        "CLT | Satellite ATCT",
+        "CLT | Charlotte TRACON",
+        "CLT | Charlotte ATCT",
+        "CIC/TMU",
     ];
 
     /**
@@ -168,6 +181,13 @@ class SupportEvents extends Command {
             $our_event->type = 2; // auto - unverified
             $our_event->vatsim_id = $event->id;
             $our_event->save();
+
+            foreach ($this->event_position_preset as $position) {
+                $position = new EventPosition;
+                $position->event_id = $our_event->id;
+                $position->name = $position;
+                $position->save();
+            }
 
             $this->info('Created ' . $event->id);
         }

--- a/app/Console/Commands/SupportEvents.php
+++ b/app/Console/Commands/SupportEvents.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Event;
+use Carbon\Carbon;
+use GuzzleHttp\Client;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Storage;
+
+class SupportEvents extends Command {
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'Events:UpdateSupportEvents';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Creates any neighbor support events that aren\'t already in the DB.';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct() {
+        parent::__construct();
+    }
+
+    protected array $pull_events_for = [
+        'all_events' => ['KZID', 'KZDC', 'KZJX', 'KZHU', 'KZME'],
+        'fno_or_live_only' => ['KZMA', 'KZNY']
+    ];
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle() {
+        $this->info("-- Updating support events - this may take a while --");
+
+        $client = new Client();
+
+        $this->info('Downloading event info from VATSIM');
+
+        $res = $client->get('https://my.vatsim.net/api/v1/events/all');
+
+        $this->info('Parsing event info JSON');
+
+        $result = json_decode($res->getBody());
+        if (is_null($result)) {
+            return;
+        }
+
+        foreach ($result->data as $event) {
+            $existing = Event::where('vatsim_id', $event->id)->first();
+            if ($existing !== null) {
+                $this->info("Skipping already processed event ".$event->id);
+                continue;
+            } // this event has already been processed
+
+            $pull_this_event = false;
+            $organizer = null;
+
+            // parse times
+            $start_time = Carbon::parse($event->start_time);
+            $end_time = Carbon::parse($event->end_time);
+
+            foreach ($event->organisers as $o) {
+                if (in_array($o->region, $this->pull_events_for['all_events'])) {
+                    $pull_this_event = true;
+                    $organizer = substr($o->region, 1);
+                    break;
+                }
+                if (in_array($o->region, $this->pull_events_for['fno_or_live_only'])) {
+                    // is it a live event?
+                    if (str_contains(strtolower($event->name), 'live')) {
+                        // live event - pull this event too
+                        $pull_this_event = true;
+                        $organizer = substr($o->region, 1);
+                        break;
+                    }
+                    // is it on a friday? (FNO)
+                    if ($start_time->dayOfWeek == 6) { // 06: Friday
+                        // FNO - pull this event too
+                        $pull_this_event = true;
+                        $organizer = substr($o->region, 1);
+                        break;
+                    }
+                }
+            }
+
+            if (!$pull_this_event) {
+                continue;
+            }
+
+            $this->info('Creating support event with vatsim id '.$event->id);
+
+            // download the event banner
+            // public/storage/event_banners/vatsim_ID.ext
+
+            $this->info($event->id.': Downloading banner');
+
+            $public_url = '/event_banners/vatsim_'.$event->id.substr($event->banner, -4);
+
+            Storage::disk('public')->put($public_url, file_get_contents($event->banner));
+
+            // create the event in our database
+
+            $this->info($event->id.': Saving to database');
+
+            $our_event = new Event;
+            $our_event->name = $event->name;
+            $our_event->host = $organizer;
+            $our_event->description = $event->description;
+            $our_event->date = $start_time->toDate();
+            $our_event->start_time = $start_time->toTimeString('minute');
+            $our_event->end_time = $end_time->toTimeString('minute');
+            $our_event->banner_path = $public_url; // TODO, we need to download this
+            $our_event->status = 0;
+            $our_event->reg = 0;
+            $our_event->type = 2; // auto - unverified
+            $our_event->vatsim_id = $event->id;
+            $our_event->save();
+
+            $this->info('Created ' . $event->id);
+        }
+    }
+}

--- a/app/Console/Commands/SupportEvents.php
+++ b/app/Console/Commands/SupportEvents.php
@@ -182,10 +182,12 @@ class SupportEvents extends Command {
             $our_event->vatsim_id = $event->id;
             $our_event->save();
 
-            foreach ($this->event_position_preset as $position) {
+            $new_event_id = Event::where('vatsim_id', $event->id)->first()->id;
+
+            foreach ($this->event_position_preset as $position_name) {
                 $position = new EventPosition;
-                $position->event_id = $our_event->id;
-                $position->name = $position;
+                $position->event_id = $new_event_id;
+                $position->name = $position_name;
                 $position->save();
             }
 

--- a/app/Console/Commands/SupportEvents.php
+++ b/app/Console/Commands/SupportEvents.php
@@ -121,6 +121,11 @@ class SupportEvents extends Command {
 
             // parse times
             $start_time = Carbon::parse($event->start_time);
+
+            if (Carbon::now()->diffInMonths($start_time) > 4) {
+                continue; // skip events that are too far out or too far in the past
+            }
+
             $end_time = Carbon::parse($event->end_time);
 
             // Airport check: is this a facility we care about?

--- a/app/Console/Commands/SupportEvents.php
+++ b/app/Console/Commands/SupportEvents.php
@@ -7,7 +7,6 @@ use App\EventPosition;
 use Carbon\Carbon;
 use GuzzleHttp\Client;
 use Illuminate\Console\Command;
-use Illuminate\Support\Facades\Storage;
 
 class SupportEvents extends Command {
     /**
@@ -156,15 +155,6 @@ class SupportEvents extends Command {
 
             $this->info('Creating support event with vatsim id '.$event->id);
 
-            // download the event banner
-            // public/storage/event_banners/vatsim_ID.ext
-
-            $this->info($event->id.': Downloading banner');
-
-            $public_url = '/event_banners/vatsim_'.$event->id.substr($event->banner, -4);
-
-            Storage::disk('public')->put($public_url, file_get_contents($event->banner));
-
             // create the event in our database
 
             $this->info($event->id.': Saving to database');
@@ -177,10 +167,8 @@ class SupportEvents extends Command {
             $new_event->start_time = $start_time->toTimeString('minute');
             $new_event->end_time = $end_time->toTimeString('minute');
 
-            $new_event->banner_path = $public_url;
-            $new_event->reduceEventBanner();
+            $new_event->banner_path = $event->banner;
 
-            $new_event->banner_path = '/storage/'.$public_url;
             $new_event->status = 0;
             $new_event->reg = 0;
             $new_event->type = 2; // auto - unverified

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -40,6 +40,7 @@ class Kernel extends ConsoleKernel {
             $schedule->command('OnlineControllers:GetControllers')->everyMinute();
         }
         $schedule->command('SetmoreAppointments:Update')->everyThirtyMinutes();
+        $schedule->command('Events:UpdateSupportEvents')->daily();
     }
 
     /**

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -40,7 +40,9 @@ class Kernel extends ConsoleKernel {
             $schedule->command('OnlineControllers:GetControllers')->everyMinute();
         }
         $schedule->command('SetmoreAppointments:Update')->everyThirtyMinutes();
-        $schedule->command('Events:UpdateSupportEvents')->daily();
+        if (FeatureToggle::isEnabled("auto_support_events")) {
+            $schedule->command('Events:UpdateSupportEvents')->daily();
+        }
     }
 
     /**

--- a/app/Event.php
+++ b/app/Event.php
@@ -29,6 +29,9 @@ class Event extends Model {
     }
 
     public function displayBannerPath() {
+        if (starts_with($this->banner_path, "http://") || starts_with($this->banner_path, "https://")) {
+            return $this->banner_path;
+        }
         $disk = Storage::disk('public');
         $filename = basename($this->banner_path);
         if ($disk->exists($this->banner_base_path . $this->banner_reduced_base_path . $filename)) {

--- a/app/Http/Controllers/AdminDash.php
+++ b/app/Http/Controllers/AdminDash.php
@@ -32,6 +32,7 @@ use Config;
 use GuzzleHttp\Client;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
 use Mail;
 
 class AdminDash extends Controller {
@@ -1416,6 +1417,17 @@ class AdminDash extends Controller {
         ]);
 
         $event = Event::find($id);
+
+        if ($request->type == 1) { // if we are setting it to a verified support event, verify the banner
+            if (starts_with($event->banner_path, "http://") || starts_with($event->banner_path, "https://")) {
+                // download the banner
+                $public_url = '/event_banners/vatsim_'.$event->vatsim_id.substr($event->banner_path, -4);
+                Storage::disk('public')->put($public_url, file_get_contents($event->banner_path));
+                $event->banner_path = $public_url;
+                $event->reduceEventBanner();
+                $event->banner_path = '/storage'.$public_url;
+            }
+        }
 
         if ($request->file('banner') != null) {
             $ext = $request->file('banner')->getClientOriginalExtension();

--- a/app/Http/Controllers/AdminDash.php
+++ b/app/Http/Controllers/AdminDash.php
@@ -1357,6 +1357,11 @@ class AdminDash extends Controller {
         return view('dashboard.admin.events.new');
     }
 
+    public function scanForEvents() {
+        Artisan::call('Events:UpdateSupportEvents', []); // start a background task to update support events
+        return redirect('/dashboard/controllers/events/')->with('success', 'Support events updated successfully.');
+    }
+
     public function saveNewEvent(Request $request) {
         $validator = $request->validate([
             'name' => 'required',

--- a/app/Http/Controllers/AdminDash.php
+++ b/app/Http/Controllers/AdminDash.php
@@ -1357,11 +1357,6 @@ class AdminDash extends Controller {
         return view('dashboard.admin.events.new');
     }
 
-    public function scanForEvents() {
-        Artisan::call('Events:UpdateSupportEvents', []); // start a background task to update support events
-        return redirect('/dashboard/controllers/events/')->with('success', 'Support events updated successfully.');
-    }
-
     public function saveNewEvent(Request $request) {
         $validator = $request->validate([
             'name' => 'required',

--- a/app/Http/Controllers/AdminDash.php
+++ b/app/Http/Controllers/AdminDash.php
@@ -1389,6 +1389,7 @@ class AdminDash extends Controller {
         $event->reduceEventBanner();
         $event->status = 0;
         $event->reg = 0;
+        $event->type = $request->type;
         $event->save();
 
         $audit = new Audit;
@@ -1437,6 +1438,7 @@ class AdminDash extends Controller {
         $event->banner_path = $public_url;
         $event->reduceEventBanner();
         $event->status = 0;
+        $event->type = $request->type;
         $event->save();
 
         $audit = new Audit;

--- a/database/migrations/2023_09_09_163102_update_events_add_type.php
+++ b/database/migrations/2023_09_09_163102_update_events_add_type.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void {
+        Schema::table('events', function ($table) {
+            // Event Types:
+            // 0 - Our Event
+            // 1 - Support Event
+            // 2 - Support Event (Autocreated & Unapproved)
+            $table->integer('type')->default(0); // Default to a normal event
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void {
+        Schema::table('events', function ($table) {
+            $table->dropColumn('type');
+        });
+    }
+};

--- a/database/migrations/2023_09_09_165648_update_events_add_vatsim_id.php
+++ b/database/migrations/2023_09_09_165648_update_events_add_vatsim_id.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void {
+        Schema::table('events', function ($table) {
+            $table->integer('vatsim_id')->nullable(); // Default to a normal event
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void {
+        Schema::table('events', function ($table) {
+            $table->dropColumn('vatsim_id');
+        });
+    }
+};

--- a/resources/views/dashboard/admin/events/edit.blade.php
+++ b/resources/views/dashboard/admin/events/edit.blade.php
@@ -37,17 +37,21 @@ New Event
         </div>
         <div class="form-group">
             <div class="row">
-                <div class="col-sm-6">
+                <div class="col-sm-4">
                     {!! Form::label('start_time', 'Start Time (Zulu)', ['class' => 'form-label']) !!}
                     <div class="input-group date" id="datetimepicker2" data-target-input="nearest">
                         {!! Form::text('start_time', $event->start_time, ['placeholder' => '00:00', 'class' => 'form-control datetimepicker-input', 'data-target' => '#datetimepicker2']) !!}
                     </div>
                 </div>
-                <div class="col-sm-6">
+                <div class="col-sm-4">
                     {!! Form::label('end_time', 'End Time (Zulu)', ['class' => 'form-label']) !!}
                     <div class="input-group date" id="datetimepicker3" data-target-input="nearest">
                         {!! Form::text('end_time', $event->end_time, ['placeholder' => '00:00', 'class' => 'form-control datetimepicker-input', 'data-target' => '#datetimepicker3']) !!}
                     </div>
+                </div>
+                <div class="col-sm-4">
+                    {!! Form::label('type', 'Event Type', ['class' => 'form-label']) !!}
+                    {!! Form::select('type', ['Local Event', 'Support Event', 'Support Event (unverified)'], $event->type, ['class' => 'form-control']) !!}
                 </div>
             </div>
         </div>

--- a/resources/views/dashboard/admin/events/new.blade.php
+++ b/resources/views/dashboard/admin/events/new.blade.php
@@ -37,17 +37,21 @@ New Event
         </div>
         <div class="form-group">
             <div class="row">
-                <div class="col-sm-6">
+                <div class="col-sm-4">
                     {!! Form::label('start_time', 'Start Time (Zulu)', ['class' => 'form-label']) !!}
                     <div class="input-group date" id="datetimepicker2" data-target-input="nearest">
                         {!! Form::text('start_time', null, ['placeholder' => '00:00', 'class' => 'form-control datetimepicker-input', 'data-target' => '#datetimepicker2']) !!}
                     </div>
                 </div>
-                <div class="col-sm-6">
+                <div class="col-sm-4">
                     {!! Form::label('end_time', 'End Time (Zulu)', ['class' => 'form-label']) !!}
                     <div class="input-group date" id="datetimepicker3" data-target-input="nearest">
                         {!! Form::text('end_time', null, ['placeholder' => '00:00', 'class' => 'form-control datetimepicker-input', 'data-target' => '#datetimepicker3']) !!}
                     </div>
+                </div>
+                <div class="col-sm-4">
+                    {!! Form::label('type', 'Event Type', ['class' => 'form-label']) !!}
+                    {!! Form::select('type', ['Local Event', 'Support Event', 'Support Event (unverified)'], 'Local Event', ['class' => 'form-control']) !!}
                 </div>
             </div>
         </div>

--- a/resources/views/dashboard/controllers/events/index.blade.php
+++ b/resources/views/dashboard/controllers/events/index.blade.php
@@ -31,7 +31,11 @@ Events
         <tbody>
             @if($events->count() > 0)
                 @foreach($events as $e)
-                    <tr>
+                    @if($e->type == 2)
+                        <tr class="alert-warning">
+                    @else
+                        <tr>
+                    @endif
                         @if($e->banner_path != null)
                             <td width="500px"><a href="/dashboard/controllers/events/view/{{ $e->id }}"><img src="{{ $e->banner_path }}" width="500px" alt="{{ $e->name }}"></a></td>
                         @else

--- a/resources/views/dashboard/controllers/events/index.blade.php
+++ b/resources/views/dashboard/controllers/events/index.blade.php
@@ -31,8 +31,10 @@ Events
         <tbody>
             @if($events->count() > 0)
                 @foreach($events as $e)
-                    @if($e->type == 2)
+                    @if($e->type == 2 && Auth::user()->isAbleTo('events'))
                         <tr class="alert-warning">
+                    @elseif($e->type == 1 && Auth::user()->isAbleTo('events'))
+                        <tr class="alert-info">
                     @else
                         <tr>
                     @endif
@@ -50,17 +52,20 @@ Events
                         </td>
                         @if(Auth::user()->isAbleTo('events'))
                             <td>
-                                @if($e->type == 2)
-                                    <button disabled class="btn btn-success" title="This event has not been verified and cannot be made public"><i class="fas fa-check"></i></button>
-                                @else
-                                    @if($e->status == 0)
-                                        <a href="/dashboard/admin/events/set-active/{{ $e->id }}" class="btn btn-success" data-toggle="tooltip" title="Unhide Event"><i class="fas fa-check"></i></a>
-                                    @elseif($e->status == 1)
-                                        <a href="/dashboard/admin/events/hide/{{ $e->id }}" class="btn btn-warning" data-toggle="tooltip" title="Hide Event"><i class="fas fa-ban"></i></a>
+
+                                <div class="btn-group" role="group" aria-label="Actions">
+                                    @if($e->type == 2)
+                                        <button disabled class="btn btn-success" title="This event has not been verified and cannot be made public"><i class="fas fa-check"></i></button>
+                                    @else
+                                        @if($e->status == 0)
+                                            <a href="/dashboard/admin/events/set-active/{{ $e->id }}" class="btn btn-success" data-toggle="tooltip" title="Unhide Event"><i class="fas fa-check"></i></a>
+                                        @elseif($e->status == 1)
+                                            <a href="/dashboard/admin/events/hide/{{ $e->id }}" class="btn btn-warning" data-toggle="tooltip" title="Hide Event"><i class="fas fa-ban"></i></a>
+                                        @endif
                                     @endif
-                                @endif
-                                <a href="/dashboard/admin/events/edit/{{ $e->id }}" class="btn btn-success simple-tooltip" data-toggle="tooltip" title="Edit"><i class="fas fa-pencil-alt"></i></a>
-                                <a href="/dashboard/admin/events/delete/{{ $e->id }}" class="btn btn-danger simple-tooltip" data-toggle="tooltip" title="Delete"><i class="fas fa-times"></i></a>
+                                        <a href="/dashboard/admin/events/edit/{{ $e->id }}" class="btn btn-success simple-tooltip" data-toggle="tooltip" title="Edit"><i class="fas fa-pencil-alt"></i></a>
+                                        <a href="/dashboard/admin/events/delete/{{ $e->id }}" class="btn btn-danger simple-tooltip" data-toggle="tooltip" title="Delete"><i class="fas fa-times"></i></a>
+                                </div>
                                     @if($e->type == 2)
                                         <p><small><i>Unverified</i></small></p>
                                     @else

--- a/resources/views/dashboard/controllers/events/index.blade.php
+++ b/resources/views/dashboard/controllers/events/index.blade.php
@@ -15,7 +15,6 @@ Events
 <div class="container">
     @if(Auth::user()->isAbleTo('events'))
         <a href="/dashboard/admin/events/new" class="btn btn-primary">New Event</a>
-        <a href="/dashboard/admin/events/scan" class="btn btn-primary">Scan for Support Events (may take a long time)</a>
         <br><br>
     @endif
     <table class="table table-bordered">

--- a/resources/views/dashboard/controllers/events/index.blade.php
+++ b/resources/views/dashboard/controllers/events/index.blade.php
@@ -15,6 +15,7 @@ Events
 <div class="container">
     @if(Auth::user()->isAbleTo('events'))
         <a href="/dashboard/admin/events/new" class="btn btn-primary">New Event</a>
+        <a href="/dashboard/admin/events/scan" class="btn btn-primary">Scan for Support Events (may take a long time)</a>
         <br><br>
     @endif
     <table class="table table-bordered">

--- a/resources/views/dashboard/controllers/events/index.blade.php
+++ b/resources/views/dashboard/controllers/events/index.blade.php
@@ -46,17 +46,25 @@ Events
                         </td>
                         @if(Auth::user()->isAbleTo('events'))
                             <td>
-                                @if($e->status == 0)
-                                    <a href="/dashboard/admin/events/set-active/{{ $e->id }}" class="btn btn-success" data-toggle="tooltip" title="Unhide Event"><i class="fas fa-check"></i></a>
-                                @elseif($e->status == 1)
-                                    <a href="/dashboard/admin/events/hide/{{ $e->id }}" class="btn btn-warning" data-toggle="tooltip" title="Hide Event"><i class="fas fa-ban"></i></a>
+                                @if($e->type == 2)
+                                    <button disabled class="btn btn-success" title="This event has not been verified and cannot be made public"><i class="fas fa-check"></i></button>
+                                @else
+                                    @if($e->status == 0)
+                                        <a href="/dashboard/admin/events/set-active/{{ $e->id }}" class="btn btn-success" data-toggle="tooltip" title="Unhide Event"><i class="fas fa-check"></i></a>
+                                    @elseif($e->status == 1)
+                                        <a href="/dashboard/admin/events/hide/{{ $e->id }}" class="btn btn-warning" data-toggle="tooltip" title="Hide Event"><i class="fas fa-ban"></i></a>
+                                    @endif
                                 @endif
                                 <a href="/dashboard/admin/events/edit/{{ $e->id }}" class="btn btn-success simple-tooltip" data-toggle="tooltip" title="Edit"><i class="fas fa-pencil-alt"></i></a>
                                 <a href="/dashboard/admin/events/delete/{{ $e->id }}" class="btn btn-danger simple-tooltip" data-toggle="tooltip" title="Delete"><i class="fas fa-times"></i></a>
-                                @if($e->status == 0)
-                                    <br>
-                                    <p><small><i>Hidden</i></small></p>
-                                @endif
+                                    @if($e->type == 2)
+                                        <p><small><i>Unverified</i></small></p>
+                                    @else
+                                        @if($e->status == 0)
+                                            <br>
+                                            <p><small><i>Hidden</i></small></p>
+                                        @endif
+                                    @endif
                             </td>
                         @endif
                     </tr>

--- a/resources/views/dashboard/controllers/events/index.blade.php
+++ b/resources/views/dashboard/controllers/events/index.blade.php
@@ -58,13 +58,13 @@ Events
                                         <button disabled class="btn btn-success" title="This event has not been verified and cannot be made public"><i class="fas fa-check"></i></button>
                                     @else
                                         @if($e->status == 0)
-                                            <a href="/dashboard/admin/events/set-active/{{ $e->id }}" class="btn btn-success" data-toggle="tooltip" title="Unhide Event"><i class="fas fa-check"></i></a>
+                                            <a href="/dashboard/admin/events/set-active/{{ $e->id }}" class="btn btn-success" data-toggle="tooltip" title="Unhide Event"><i class="fas fa-check fa-fw"></i></a>
                                         @elseif($e->status == 1)
-                                            <a href="/dashboard/admin/events/hide/{{ $e->id }}" class="btn btn-warning" data-toggle="tooltip" title="Hide Event"><i class="fas fa-ban"></i></a>
+                                            <a href="/dashboard/admin/events/hide/{{ $e->id }}" class="btn btn-warning" data-toggle="tooltip" title="Hide Event"><i class="fas fa-ban fa-fw"></i></a>
                                         @endif
                                     @endif
-                                        <a href="/dashboard/admin/events/edit/{{ $e->id }}" class="btn btn-success simple-tooltip" data-toggle="tooltip" title="Edit"><i class="fas fa-pencil-alt"></i></a>
-                                        <a href="/dashboard/admin/events/delete/{{ $e->id }}" class="btn btn-danger simple-tooltip" data-toggle="tooltip" title="Delete"><i class="fas fa-times"></i></a>
+                                        <a href="/dashboard/admin/events/edit/{{ $e->id }}" class="btn btn-success simple-tooltip" data-toggle="tooltip" title="Edit"><i class="fas fa-pencil-alt fa-fw"></i></a>
+                                        <a href="/dashboard/admin/events/delete/{{ $e->id }}" class="btn btn-danger simple-tooltip" data-toggle="tooltip" title="Delete"><i class="fas fa-times fa-fw"></i></a>
                                 </div>
                                     @if($e->type == 2)
                                         <p><small><i>Unverified</i></small></p>

--- a/resources/views/dashboard/controllers/events/view.blade.php
+++ b/resources/views/dashboard/controllers/events/view.blade.php
@@ -37,6 +37,24 @@ View Event
                                                                                  title="Showing times in {{ $timezone }}. You can change this on your profile."><i
                                         class="fas fa-info-circle"></i></a>)
                         </h5>
+                        <h5><b>Type:</b>
+                            @if(Auth::user()->isAbleTo('events'))
+                                @if($event->type == 0)
+                                    Local Event
+                                @elseif($event->type == 1)
+                                    Support Event
+                                @else
+                                    Unverified Support Event
+                                    <a style="color:inherit" href="#" data-toggle="tooltip" title="Verify by setting the Event Type to 'Support Event' on the Edit Event page."><i class="fas fa-info-circle"></i></a>
+                                @endif
+                            @else
+                                @if($event->type == 0)
+                                    Local Event
+                                @else
+                                    Support Event
+                                @endif
+                            @endif
+                        </h5>
                     <p><b>Additional Information:</b></p>
                     <p>{!! $event->description !!}</p>
                 </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -182,7 +182,6 @@ Route::prefix('dashboard')->middleware('auth')->group(function () {
         Route::prefix('events')->middleware('permission:events')->group(function () {
             Route::get('/new', 'AdminDash@newEvent');
             Route::post('/new', 'AdminDash@saveNewEvent');
-            Route::get('/scan', 'AdminDash@scanForEvents');
             Route::post('/positions/add/{id}', 'AdminDash@addPosition');
             Route::get('/position/delete/{id}', 'AdminDash@removePosition');
             Route::post('/positions/assign/{id}', 'AdminDash@assignPosition');

--- a/routes/web.php
+++ b/routes/web.php
@@ -182,6 +182,7 @@ Route::prefix('dashboard')->middleware('auth')->group(function () {
         Route::prefix('events')->middleware('permission:events')->group(function () {
             Route::get('/new', 'AdminDash@newEvent');
             Route::post('/new', 'AdminDash@saveNewEvent');
+            Route::get('/scan', 'AdminDash@scanForEvents');
             Route::post('/positions/add/{id}', 'AdminDash@addPosition');
             Route::get('/position/delete/{id}', 'AdminDash@removePosition');
             Route::post('/positions/assign/{id}', 'AdminDash@assignPosition');


### PR DESCRIPTION
This PR will:
* Automate the creation of support events
* Add a new console command to create support events
* Slightly change the event index view to show details on event types
* Slightly change the event create and edit views to add a field for event types
* Add a new column to `events` to record the event type
* Close #351 
