### PR TITLE
#406 Adds visitor auto-roster update

### DIFF
--- a/app/Console/Commands/RosterUpdate.php
+++ b/app/Console/Commands/RosterUpdate.php
@@ -95,7 +95,7 @@ class RosterUpdate extends Command {
                 $visitor->visitor_from = $v->data->facility;
                 $visitor->save();
             } else {
-                exit(1);
+                continue;
             }
         }
 

--- a/app/Console/Commands/RosterUpdate.php
+++ b/app/Console/Commands/RosterUpdate.php
@@ -83,6 +83,20 @@ class RosterUpdate extends Command {
             $user->save();
         }
 
+        $visitors = User::where('visitor', 1)->where('status', 1)->where('api_exempt', 0)->get();
+        foreach ($visitors as $visitor) {
+            $res = $client->get(Config::get('vatusa.base').'/v2/user/'.$visitor->id);
+            if ($res->getStatusCode() == "200") {
+                $v = json_decode($res->getBody());
+                $visitor->fname = $v->data->fname;
+                $visitor->lname = $v->data->lname;
+                $visitor->email = $v->data->email;
+                $visitor->rating_id = $v->data->rating;
+                $visitor->visitor_from = $v->data->facility;
+                $visitor->save();
+            }
+        }
+
         $users = User::where('visitor', 0)->where('status', 1)->where('api_exempt', 0)->get();
         foreach ($users as $u) {
             $delete = true;

--- a/app/Console/Commands/RosterUpdate.php
+++ b/app/Console/Commands/RosterUpdate.php
@@ -85,7 +85,7 @@ class RosterUpdate extends Command {
 
         $visitors = User::where('visitor', 1)->where('status', 1)->where('api_exempt', 0)->get();
         foreach ($visitors as $visitor) {
-            $res = $client->get(Config::get('vatusa.base').'/v2/user/'.$visitor->id);
+            $res = $client->request('GET', Config::get('vatusa.base').'/v2/user/'.$visitor->id, ['http_errors' => false]);
             if ($res->getStatusCode() == "200") {
                 $v = json_decode($res->getBody());
                 $visitor->fname = $v->data->fname;
@@ -94,6 +94,8 @@ class RosterUpdate extends Command {
                 $visitor->rating_id = $v->data->rating;
                 $visitor->visitor_from = $v->data->facility;
                 $visitor->save();
+            } else {
+                exit(1);
             }
         }
 


### PR DESCRIPTION
This PR will:
* Adds logic to the roster update console command that pulls visitor information from VATUSA and updates the ZTL roster
* Close #406 
