### PR TITLE
NOISS: Removes VATSTAR link from the Navbar

### DIFF
--- a/resources/views/inc/navbar.blade.php
+++ b/resources/views/inc/navbar.blade.php
@@ -47,7 +47,6 @@
                         <a class="nav-link dropdown-toggle" href="#" id="pilots" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Pilots</a>
                         <div class="dropdown-menu" aria-labelledby="pilots">
                             <a class="dropdown-item" href="https://www.aviationapi.com/charts" target="_blank">Charts</a>
-                            <a class="dropdown-item" href="http://www.vatstar.com/" target="_blank">VATSTAR Training</a>
                             <a class="dropdown-item" href="https://www.aviationweather.gov/" target="_blank">Weather</a>
                             <a class="dropdown-item" href="/pilots/scenery">Scenery</a>
                             <a class="dropdown-item" href="/pilots/airports">Airports</a>


### PR DESCRIPTION
This PR will:
* Removes VATSTAR link from the navbar - VATSTAR is shutting down on 1 Jan 2024
