### PR TITLE
#432 Fix null email issues

### DIFF
--- a/app/Console/Commands/RosterUpdate.php
+++ b/app/Console/Commands/RosterUpdate.php
@@ -85,7 +85,7 @@ class RosterUpdate extends Command {
 
         $visitors = User::where('visitor', 1)->where('status', 1)->where('api_exempt', 0)->get();
         foreach ($visitors as $visitor) {
-            $res = $client->request('GET', Config::get('vatusa.base').'/v2/user/'.$visitor->id, ['http_errors' => false]);
+            $res = $client->request('GET', Config::get('vatusa.base').'/v2/user/'.$visitor->id.'?apikey='.Config::get('vatusa.api_key'), ['http_errors' => false]);
             if ($res->getStatusCode() == "200") {
                 $v = json_decode($res->getBody());
                 $visitor->fname = $v->data->fname;

--- a/app/Listeners/ValidateEmail.php
+++ b/app/Listeners/ValidateEmail.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Listeners;
+
+use Illuminate\Mail\Events\MessageSending;
+
+class CheckEmailPreferences {
+    public function handle(MessageSending $event) {
+        // Ensures 'to' email address is valid before attempting to send email
+        $to_address = $event->message->getTo(); // ['john@doe.com' => 'John Doe']
+        $valid_to_address = [];
+        for ($e=0; $e<count($to_address); $e++) {
+            $valid_email_addr = filter_var(key($to_address[$e]), FILTER_VALIDATE_EMAIL);
+            if ($valid_email_addr && !empty(key($to_address[$e]))) {
+                $valid_to_address[$valid_email_addr] = $to_address[$e];
+            }
+        }
+        if (count($valid_to_address) == 0) {
+            return false; // Stop the mailer
+        } else {
+            $event->message->setTo($valid_to_address);
+            return $event;
+        }
+    }
+}

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -15,6 +15,9 @@ class EventServiceProvider extends ServiceProvider {
         'App\Events\Event' => [
             'App\Listeners\EventListener',
         ],
+        'Illuminate\Mail\Events\MessageSending' => [
+            'App\Listeners\ValidateEmail',
+        ]
     ];
 
     /**


### PR DESCRIPTION
This PR will:
* Adds protection to the email routine through a listener and embedded 'to' address validator
* Fixes the issue that was wiping email addresses from the visitor roster (VATUSA API authentication)
* Close #432 
