### PR TITLE
#410 Implement name privacy

### DIFF
--- a/app/Console/Commands/RosterUpdate.php
+++ b/app/Console/Commands/RosterUpdate.php
@@ -78,6 +78,7 @@ class RosterUpdate extends Command {
             $user->rating_id = $r->rating;
             $user->visitor = 0;
             $user->status = 1;
+            $user->name_privacy = ($r->flag_nameprivacy == 'true') ? 1 : 0;
             $user->added_to_facility = substr($r->facility_join, 0, 10) . ' ' . substr($r->facility_join, 11, 8);
 
             $user->save();
@@ -93,6 +94,7 @@ class RosterUpdate extends Command {
                 $visitor->email = $v->data->email;
                 $visitor->rating_id = $v->data->rating;
                 $visitor->visitor_from = $v->data->facility;
+                $visitor->name_privacy = ($v->data->flag_nameprivacy == 'true') ? 1 : 0;
                 $visitor->save();
             } else {
                 continue;

--- a/app/User.php
+++ b/app/User.php
@@ -22,6 +22,13 @@ class User extends Authenticatable {
         return $this->lname.', '.$this->fname;
     }
 
+    public function getBackwardsPublicNameAttribute() {
+        if ($this->name_privacy == 1) {
+            return $this->id.', '.$this->fname;
+        }
+        return $this->lname.', '.$this->fname;
+    }
+
     public function getBackwardsNameRatingAttribute() {
         return $this->backwards_name . ' - ' . $this->rating_short;
     }

--- a/database/migrations/2024_01_18_102000_update_roster_add_privacy.php
+++ b/database/migrations/2024_01_18_102000_update_roster_add_privacy.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void {
+        Schema::table('roster', function ($table) {
+            $table->integer('name_privacy')->default('0');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void {
+        Schema::table('roster', function ($table) {
+            $table->dropColumn('name_privacy');
+        });
+    }
+};

--- a/resources/views/site/roster.blade.php
+++ b/resources/views/site/roster.blade.php
@@ -77,7 +77,7 @@ Roster
                                 @elseif($c->hasRole('mtr'))
                                 <span class="badge badge-info">MTR</span>
                                 @endif
-                                {{ $c->backwards_name }}
+                                {{ $c->backwards_public_name }}
                             </td>
                             <td class="text-center">{{$c->initials}}</td>
                             <td class="text-center">{{ $c->rating_short }}</td>


### PR DESCRIPTION
This PR will:
* Pulls name privacy flag from VATUSA during the daily roster update routine
* When flag is set, will replace a member's last name with their CID on the public-facing roster
* Close #410 
