### PR TITLE
#476 Adds selectors for stats view cell coloring

### DIFF
--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -198,12 +198,14 @@ div.pyrite-bg {
 }
 
 div.hours-danger,
-li.hours-danger {
+li.hours-danger,
+td.hours-danger {
   background-color: #e6b0aa;
 }
 
 div.hours-success,
-li.hours-success {
+li.hours-success,
+td.hours-success {
   background-color: #a9dfbf;
 }
 


### PR DESCRIPTION
This PR will:
* Corrects a bug in the stats view table cell coloring by adding the td selector to color selectors in sass source file
* Close #476 
