### PR TITLE
#482 Typo in Clearance Delivery Section of Pilot Guide

### DIFF
--- a/resources/views/site/pilot_guide_atl.blade.php
+++ b/resources/views/site/pilot_guide_atl.blade.php
@@ -247,7 +247,7 @@ return $badge;
             </div>
             <h3>Receiving a clearance</h3>
             <p> After filing a flight plan, you should receive your clearance from ATC. If you have not received a clearance after a reasonable
-                about of time, you should call {!! fetchBadge($del)['position'] !!} on {!! fetchBadge($del)['frequency'] !!} and request your
+                amount of time, you should call {!! fetchBadge($del)['position'] !!} on {!! fetchBadge($del)['frequency'] !!} and request your
                 clearance.</p>
             <p class="font-italic">Example: Atlanta Clearance, Delta 1234 clearance to Charlotte ready to copy.</p>
             <p>Aircraft with CPDLC capabilities should expect to receive a computerized pre-departure clearance from ATC. Because ATC sends this


### PR DESCRIPTION
This PR will:
* [fixed typo in Clearance section now should say "amount"]
* Close #482 
