### PR TITLE
NOISS Add primary key of id to roster

### DIFF
--- a/database/migrations/2024_03_06_000921_add_primary_key_to_roster.php
+++ b/database/migrations/2024_03_06_000921_add_primary_key_to_roster.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void {
+        Schema::table('roster', function (Blueprint $table) {
+            $table->primary('id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void {
+        Schema::table('roster', function (Blueprint $table) {
+            $table->dropPrimary();
+        });
+    }
+};


### PR DESCRIPTION
This PR will:
* Add `id` as the primary key to the roster table
