### PR TITLE
NOISS Update CODEOWNERS to be code_reviewers instead of web_team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ZTL-ARTCC/web_team
+* @ZTL-ARTCC/code_reviewers


### PR DESCRIPTION
This PR will:
* Update the CODEOWNERS file so that @ZTL-ARTCC/code_reviewers is marked as the code owner instead of web_team, so that it's the people who are marked for review