### PR TITLE
#498 Add privacy flag to user profile

### DIFF
--- a/resources/views/dashboard/controllers/profile.blade.php
+++ b/resources/views/dashboard/controllers/profile.blade.php
@@ -116,7 +116,8 @@ Profile
         <div class="col-sm-4">
             <h4>My Information</h4>
             <br>
-            <p><b>CID:</b> {{ Auth::id() }}</p>
+	    <p><b>CID:</b> {{ Auth::id() }}</p>
+	    <p><b>Name privacy:</b> {{ Auth:user()->name_privacy == 1 ? 'Enabled' : 'Disabled' }} <a class="info-tooltip" href="https://www.vatusa.net/my/profile" target="_blank" data-toggle="tooltip" title="Click here to update - link to VATUSA profile"><i class="fas fa-info-circle"></i></a></p>
             <p><b>Name:</b> {{ Auth::user()->full_name }}</p>
             <p><b>Rating:</b> {{ Auth::user()->rating_long }}</p>
             <p><b>Email:</b> {{ Auth::user()->email }} <a class="info-tooltip" href="https://my.vatsim.net/user/email" target="_blank" data-toggle="tooltip" title="Click Here to Update (It may take up to an hour for changes to be reflected)"><i class="fas fa-info-circle"></i></a></p>

--- a/resources/views/dashboard/controllers/profile.blade.php
+++ b/resources/views/dashboard/controllers/profile.blade.php
@@ -117,10 +117,10 @@ Profile
             <h4>My Information</h4>
             <br>
 	    <p><b>CID:</b> {{ Auth::id() }}</p>
-	    <p><b>Name Privacy:</b> {{ Auth::user()->name_privacy == 1 ? 'Enabled' : 'Disabled' }} <a class="info-tooltip" href="https://www.vatusa.net/my/profile" target="_blank" data-toggle="tooltip" title="Click here to update"><i class="fas fa-info-circle"></i></a></p>
             <p><b>Name:</b> {{ Auth::user()->full_name }}</p>
             <p><b>Rating:</b> {{ Auth::user()->rating_long }}</p>
             <p><b>Email:</b> {{ Auth::user()->email }} <a class="info-tooltip" href="https://my.vatsim.net/user/email" target="_blank" data-toggle="tooltip" title="Click Here to Update (It may take up to an hour for changes to be reflected)"><i class="fas fa-info-circle"></i></a></p>
+            <p><b>Name Privacy:</b> {{ Auth::user()->name_privacy == 1 ? 'Enabled' : 'Disabled' }} <a class="info-tooltip" href="https://www.vatusa.net/my/profile" target="_blank" data-toggle="tooltip" title="Click here to update"><i class="fas fa-info-circle"></i></a></p>
             {!! Form::open(['action' => ['ControllerDash@updateInfo', Auth::id()]]) !!}
             @csrf
                 <div class="row">

--- a/resources/views/dashboard/controllers/profile.blade.php
+++ b/resources/views/dashboard/controllers/profile.blade.php
@@ -117,7 +117,7 @@ Profile
             <h4>My Information</h4>
             <br>
 	    <p><b>CID:</b> {{ Auth::id() }}</p>
-	    <p><b>Name privacy:</b> {{ Auth::user()->name_privacy == 1 ? 'Enabled' : 'Disabled' }} <a class="info-tooltip" href="https://www.vatusa.net/my/profile" target="_blank" data-toggle="tooltip" title="Click here to update - link to VATUSA profile"><i class="fas fa-info-circle"></i></a></p>
+	    <p><b>Name Privacy:</b> {{ Auth::user()->name_privacy == 1 ? 'Enabled' : 'Disabled' }} <a class="info-tooltip" href="https://www.vatusa.net/my/profile" target="_blank" data-toggle="tooltip" title="Click here to update"><i class="fas fa-info-circle"></i></a></p>
             <p><b>Name:</b> {{ Auth::user()->full_name }}</p>
             <p><b>Rating:</b> {{ Auth::user()->rating_long }}</p>
             <p><b>Email:</b> {{ Auth::user()->email }} <a class="info-tooltip" href="https://my.vatsim.net/user/email" target="_blank" data-toggle="tooltip" title="Click Here to Update (It may take up to an hour for changes to be reflected)"><i class="fas fa-info-circle"></i></a></p>

--- a/resources/views/dashboard/controllers/profile.blade.php
+++ b/resources/views/dashboard/controllers/profile.blade.php
@@ -117,7 +117,7 @@ Profile
             <h4>My Information</h4>
             <br>
 	    <p><b>CID:</b> {{ Auth::id() }}</p>
-	    <p><b>Name privacy:</b> {{ Auth:user()->name_privacy == 1 ? 'Enabled' : 'Disabled' }} <a class="info-tooltip" href="https://www.vatusa.net/my/profile" target="_blank" data-toggle="tooltip" title="Click here to update - link to VATUSA profile"><i class="fas fa-info-circle"></i></a></p>
+	    <p><b>Name privacy:</b> {{ Auth::user()->name_privacy == 1 ? 'Enabled' : 'Disabled' }} <a class="info-tooltip" href="https://www.vatusa.net/my/profile" target="_blank" data-toggle="tooltip" title="Click here to update - link to VATUSA profile"><i class="fas fa-info-circle"></i></a></p>
             <p><b>Name:</b> {{ Auth::user()->full_name }}</p>
             <p><b>Rating:</b> {{ Auth::user()->rating_long }}</p>
             <p><b>Email:</b> {{ Auth::user()->email }} <a class="info-tooltip" href="https://my.vatsim.net/user/email" target="_blank" data-toggle="tooltip" title="Click Here to Update (It may take up to an hour for changes to be reflected)"><i class="fas fa-info-circle"></i></a></p>


### PR DESCRIPTION
This PR will:
* Between Email and CID add a new item Name Privacy with status Enabled or Disabled. Name privacy flag is set in the user model with the flag $user->name_privacy as a boolean and automatically synced from VATUSA (it's not set on our website, just synced from USA's database)
* Add a tooltip next to the name privacy field (like the email field) that says Click here to update - link to VATUSA profile and the link should go to: https://www.vatusa.net/my/profile
* Close #498 
