### PR TITLE
NOISS: Correct local dev WM role assignment

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -124,7 +124,7 @@ class LoginController extends Controller {
                 $devUser->save();
                 $userstatuscheck = $devUser;
             }
-            $userstatuscheck->attachRole('wm');
+            $userstatuscheck->addRole('wm');
             $userstatuscheck->save();
 
             auth()->login($userstatuscheck, true);

--- a/routes/web.php
+++ b/routes/web.php
@@ -286,29 +286,3 @@ Route::prefix('dashboard')->middleware('auth')->group(function () {
 /*
 *   End Controller Dashboard
 */
-
-/*
-*   Cron Jobs
-*   URL: https://ztlv2.team-stringer.com/cron-job/run?j=[Cron Job]&t=[Token]
-*/
-//Route::get('/cron-job/run', 'CronController@index');
-/*
-*   End Cron Job
-*/
-
-/*
-*	Webmaster Permission Grant
-*	Use this to grant yourself webmaster privileges. Should be disabled for security reasons.
-*/
-
-/*
-Route::get('/laratrust', function () {
-    $user = App\User::find(1315134);
-
-    $user->addRole('wm');
-});
-*/
-
-/*
-*	End Webmaster Permission Grant
-*/


### PR DESCRIPTION
This PR will:
* When I updated Laratrust to 8x, an unmerged change didn't get updated to the new method call. This updates the method call to properly assign the WM role to local users in a dev environment
