### PR TITLE
NOISS: Paginate events view

### DIFF
--- a/app/Event.php
+++ b/app/Event.php
@@ -34,6 +34,10 @@ class Event extends Model {
         return $date;
     }
 
+    public function getDateStampAttribute() {
+        return strtotime($this->date);
+    }
+
     public static function fetchVisibleEvents() {
         $now = Carbon::now();
         $events = Event::where('status', Event::$STATUSES["VISIBLE"])->get()->filter(function ($e) use ($now) {

--- a/app/Http/Controllers/ControllerDash.php
+++ b/app/Http/Controllers/ControllerDash.php
@@ -361,13 +361,10 @@ class ControllerDash extends Controller {
 
     public function showEvents() {
         if (Auth::user()->isAbleTo('events')||Auth::user()->hasRole('events-team')) {
-            $events = Event::where('status', 0)->orWhere('status', 1)->get()->sortByDesc(function ($e) {
-                return strtotime($e->date);
-            });
+            $events = Event::all()->sortByDesc('date_stamp')->paginate(10);
+
         } else {
-            $events = Event::where('status', 1)->get()->sortByDesc(function ($e) {
-                return strtotime($e->date);
-            });
+            $events = Event::where('status', 1)->get()->sortByDesc('date_stamp');
         }
         foreach ($events as $e) {
             $e->banner_path = $e->displayBannerPath();

--- a/app/Http/Controllers/ControllerDash.php
+++ b/app/Http/Controllers/ControllerDash.php
@@ -362,7 +362,6 @@ class ControllerDash extends Controller {
     public function showEvents() {
         if (Auth::user()->isAbleTo('events')||Auth::user()->hasRole('events-team')) {
             $events = Event::all()->sortByDesc('date_stamp')->paginate(10);
-
         } else {
             $events = Event::where('status', 1)->get()->sortByDesc('date_stamp');
         }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -32,7 +32,7 @@ class AppServiceProvider extends ServiceProvider {
          * @param string $pageName
          * @return array
          */
-        Collection::macro('paginate', function($perPage, $total = null, $page = null, $pageName = 'page'): LengthAwarePaginator {
+        Collection::macro('paginate', function ($perPage, $total = null, $page = null, $pageName = 'page'): LengthAwarePaginator {
             $page = $page ?: LengthAwarePaginator::resolveCurrentPage($pageName);
 
             return new LengthAwarePaginator(

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -20,6 +20,30 @@ class AppServiceProvider extends ServiceProvider {
         Blade::if('toggle', function ($toggle_name) {
             return toggleEnabled($toggle_name);
         });
+
+        /**
+         * Paginate a standard Laravel Collection.
+         *
+         * @param int $perPage
+         * @param int $total
+         * @param int $page
+         * @param string $pageName
+         * @return array
+         */
+        Collection::macro('paginate', function($perPage, $total = null, $page = null, $pageName = 'page'): LengthAwarePaginator {
+            $page = $page ?: LengthAwarePaginator::resolveCurrentPage($pageName);
+
+            return new LengthAwarePaginator(
+                $this->forPage($page, $perPage)->values(),
+                $total ?: $this->count(),
+                $perPage,
+                $page,
+                [
+                    'path' => LengthAwarePaginator::resolveCurrentPath(),
+                    'pageName' => $pageName,
+                ]
+            );
+        });
     }
 
     /**
@@ -28,6 +52,5 @@ class AppServiceProvider extends ServiceProvider {
      * @return void
      */
     public function register(): void {
-        //
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,7 +2,9 @@
 
 namespace App\Providers;
 
+use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Pagination\Paginator;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\ServiceProvider;

--- a/resources/views/dashboard/controllers/events/index.blade.php
+++ b/resources/views/dashboard/controllers/events/index.blade.php
@@ -86,5 +86,8 @@ Events
             @endif
         </tbody>
     </table>
+    @if(method_exists($events,'links'))
+       {!! $events->links() !!}
+    @endif
 </div>
 @endsection


### PR DESCRIPTION
This PR will:
* Paginates the show events view for events staff only to 10 items per load. This view gets slower to load each time we add additional events due to all of the banners. Paginating this view will maintain a consistent load experience independent of the number of events/banners.
* No change to the events view for non-staff (view will still show all active events)
* Cleans up some sloppy string-to-timestamp code that I previously wrote by shifting the conversion into a model attribute so it is chainable
