### PR TITLE
NOISS: Fix bracket bug in Edit Calendar

### DIFF
--- a/resources/views/dashboard/admin/calendar/edit.blade.php
+++ b/resources/views/dashboard/admin/calendar/edit.blade.php
@@ -38,7 +38,7 @@ Edit Calendar Event/News
     </div>
     <div class="form-group">
         <label for="body">Additional Information</label>
-        {{ html()->textarea('body', $calendar->body)->class(['form-control', 'text-editor')->placeholder('Required') }}
+        {{ html()->textarea('body', $calendar->body)->class(['form-control', 'text-editor'])->placeholder('Required') }}
     </div>
     <div class="form-group">
         <label for="type">Type of Post</label>


### PR DESCRIPTION
This PR will:
* Fix a small issue with displaying the Edit Calendar entry by closing a bracket that wasn't closed before and caused an internal website error
