### PR TITLE
NOISS: Correct roster update discord_id

### DIFF
--- a/app/Console/Commands/RosterUpdate.php
+++ b/app/Console/Commands/RosterUpdate.php
@@ -100,7 +100,7 @@ class RosterUpdate extends Command {
                 $visitor->rating_id = $v->data->rating;
                 $visitor->visitor_from = $v->data->facility;
                 $visitor->name_privacy = ($v->data->flag_nameprivacy == 'true') ? 1 : 0;
-                $visitor->discord = $v->discord_id;
+                $visitor->discord = $v->data->discord_id;
                 $visitor->save();
             } else {
                 continue;

--- a/resources/views/dashboard/controllers/profile.blade.php
+++ b/resources/views/dashboard/controllers/profile.blade.php
@@ -150,7 +150,7 @@ Profile
                     </div>
                 </div>
 
-                <div class="row">
+                <div class="row mb-4">
                     <div class="col-4">
                         <button class="btn btn-success" type="submit">Save Profile</button>
                     </div>


### PR DESCRIPTION
This PR will:
* Fixes a minor bug associated with updating the roster discord_id field for visitors
