### PR TITLE
NOISS Upgrade actions to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: load/save cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
               vendor
@@ -59,7 +59,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: load/save cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
               vendor

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
         run: composer install
 
       - name: setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ needs.setup-variables.outputs.node-version }}
 
@@ -79,7 +79,7 @@ jobs:
         run: composer install --no-dev
 
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ needs.setup-variables.outputs.node-version }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,7 +101,7 @@ jobs:
           tar --exclude=${{ inputs.artifact-name }}.tar.gz -zcvf ${{ inputs.artifact-name }}.tar.gz .
 
       - name: create artifact for deploy
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.artifact-name }}
           path: ./${{ inputs.artifact-name }}.tar.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: load/save cache
         uses: actions/cache@v3
@@ -56,7 +56,7 @@ jobs:
 
     steps:
       - name: checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: load/save cache
         uses: actions/cache@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: retrieve artifact for deploy
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.artifact-name }}
 

--- a/.github/workflows/setup-variables.yml
+++ b/.github/workflows/setup-variables.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - id: get-php-version
         run: |
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
This PR will:
* Upgrade the following actions to v4
  * actions/checkout
  * actions/cache
  * actions/setup-node
  * actions/upload
  * actions-download
