### PR TITLE
NOISS: Fix pilot passport achievement awards

### DIFF
--- a/app/Console/Commands/PilotPassportActivityUpdate.php
+++ b/app/Console/Commands/PilotPassportActivityUpdate.php
@@ -117,7 +117,7 @@ class PilotPassportActivityUpdate extends Command {
         foreach ($challenges as $challenge) {
             $challenge_previously_awarded = PilotPassportAward::where('cid', $pilot->id)->where('challenge_id', $challenge->id)->first();
             if ($challenge_previously_awarded) {
-                break;
+                continue;
             }
             $challenge_airfields = PilotPassportAirfieldMap::where('mapped_to', $challenge->id)->orderBy('airfield', 'asc')->pluck('airfield')->toArray();
             $phase_complete = true;


### PR DESCRIPTION
This PR will:
* Updates the pilot passport update routine to fix a minor bug that prevents multiple achievements from being logged
