### PR TITLE
NOISS: Prevent OTS center unknown position fail

### DIFF
--- a/app/Ots.php
+++ b/app/Ots.php
@@ -49,6 +49,7 @@ class Ots extends Model {
 
     public function getPositionNameAttribute() {
         $pos = $this->position;
+        $position = 'Unknown/Legacy';
         if ($pos == 0) {
             $position = 'Minor Delivery/Ground';
         } elseif ($pos == 1) {


### PR DESCRIPTION
This PR will:
* An instructor created an OTS for a training type that should never get an OTS (Mentor Training) which caused the OTS center to fail with an error. This fix ensures that the OTS center position lookup always returns a string value.
