### PR TITLE
NOISS: Protect scheddy API call from cURL errors

### DIFF
--- a/app/Http/Controllers/ControllerDash.php
+++ b/app/Http/Controllers/ControllerDash.php
@@ -178,7 +178,9 @@ class ControllerDash extends Controller {
                 Config::get('scheddy.base').'/api/userSessions/'.$user_id,
                 ['headers' => [
                     'Authorization' => 'Bearer '.Config::get('scheddy.api_key')
-                ]]
+                ],
+                'http_errors' => false
+                ]
             );
 
             if ($res->getStatusCode() == "200") {


### PR DESCRIPTION
This PR will:
* Prevents 500 result from scheddy API call from crashing the profile view
