### PR TITLE
NOISS: Update TA Stats Filters

### DIFF
--- a/app/Http/Controllers/TrainingDash.php
+++ b/app/Http/Controllers/TrainingDash.php
@@ -548,7 +548,7 @@ class TrainingDash extends Controller {
         }
         // Training sessions, type, and hours by instructor
         $trainers = $trainerSessions = [];
-        $activeRoster = User::where('status', '1')->where('visitor', '0')->get()->unique('id');
+        $activeRoster = User::where('status', '1')->get()->unique('id');
         foreach ($activeRoster as $activeUser) {
             if ($activeUser->getTrainPositionAttribute() > 0) {
                 $trainers[] = $activeUser;


### PR DESCRIPTION
This PR will:
* Allow the TA stats to show training staff that are facility visitors (such as VATUSA staff who hold a MTR or INS rating at ZTL)
