### PR TITLE
NOISS: Bump bootstrap to v4.6.2

### DIFF
--- a/resources/views/dashboard/admin/bronze-mic.blade.php
+++ b/resources/views/dashboard/admin/bronze-mic.blade.php
@@ -23,13 +23,13 @@ if (!in_array($sort, ['localsort', 'bronzesort', 'pyritesort'])) { $sort = 'bron
     @endif
     <div class="row">
         <div class="col-sm-2">
-            <a class="btn btn-primary" href="/dashboard/admin/bronze-mic/<?=$sort?>/<?=$pyr?>/<?=$pm?>"><i class="fa fa-arrow-left"></i> Previous Month</a></li>
+            <a class="btn btn-primary text-nowrap" href="/dashboard/admin/bronze-mic/<?=$sort?>/<?=$pyr?>/<?=$pm?>"><i class="fa fa-arrow-left"></i> Previous Month</a></li>
         </div>
         <div class="col-sm-8">
             <center><h4>Showing Eligible Hours for <?=$mname?> 20<?=$year?></h4></center>
         </div>
         <div class="col-sm-2" align="right">
-            <a class="btn btn-primary" href="/dashboard/admin/bronze-mic/<?=$sort?>/<?=$nyr?>/<?=$nm?>">Next Month <i class="fa fa-arrow-right"></i></a>
+            <a class="btn btn-primary text-nowrap" href="/dashboard/admin/bronze-mic/<?=$sort?>/<?=$nyr?>/<?=$nm?>">Next Month <i class="fa fa-arrow-right"></i></a>
         </div>
     </div>
     <div class="row">

--- a/resources/views/dashboard/admin/roster/edit.blade.php
+++ b/resources/views/dashboard/admin/roster/edit.blade.php
@@ -158,11 +158,11 @@ Update Controller
             </div>
             <div class="row">
                 <div class="col-sm-1">
-                    <button class="btn btn-success" type="submit"><i class="fas fa-save"></i>&nbsp;Save</button>
+                    <button class="btn btn-success text-nowrap" type="submit"><i class="fas fa-save"></i>&nbsp;Save</button>
                 </div>
 
                 <div class="col-sm-1">
-                    <a href="{{ url()->previous() }}" class="btn btn-danger"><i class="fas fa-undo"></i>&nbsp;Cancel</a>
+                    <a href="{{ url()->previous() }}" class="btn btn-danger text-nowrap"><i class="fas fa-undo"></i>&nbsp;Cancel</a>
                 </div>
             </div>
         </div>
@@ -278,11 +278,11 @@ Update Controller
             </div>
             <div class="row">
                 <div class="col-sm-1">
-                    <button class="btn btn-success" type="submit"><i class="fas fa-save"></i>&nbsp;Save</button>
+                    <button class="btn btn-success text-nowrap" type="submit"><i class="fas fa-save"></i>&nbsp;Save</button>
                 </div>
 
                 <div class="col-sm-1">
-                    <a href="{{ url()->previous() }}" class="btn btn-danger"><i class="fas fa-undo"></i>&nbsp;Cancel</a>
+                    <a href="{{ url()->previous() }}" class="btn btn-danger text-nowrap"><i class="fas fa-undo"></i>&nbsp;Cancel</a>
                 </div>
             </div>
         </div>

--- a/resources/views/dashboard/controllers/profile.blade.php
+++ b/resources/views/dashboard/controllers/profile.blade.php
@@ -193,13 +193,13 @@ Profile
 
                 <div class="row mb-4">
                     <div class="col-4">
-                        <button class="btn btn-success" type="submit">Save Profile</button>
+                        <button class="btn btn-success text-nowrap" type="submit">Save Profile</button>
                     </div>
 
                     @toggle('discord_role_updater')
                         @if(Auth::user()->discord)
                             <div class="col-4">
-                                <a href="/dashboard/controllers/profile/discord" class="btn btn-success" type="button">Update Discord Roles</a>
+                                <a href="/dashboard/controllers/profile/discord" class="btn btn-success text-nowrap" type="button">Update Discord Roles</a>
                             </div>profile.
                         @else
                             <div class="col-4">

--- a/resources/views/inc/stats.blade.php
+++ b/resources/views/inc/stats.blade.php
@@ -34,13 +34,13 @@ if ($month == 12) { $nm = 1; $nyr = $year + 1; } else { $nm = $month + 1; $nyr =
     <hr>
     <div class="row">
         <div class="col-sm-2">
-            <a class="btn btn-primary" href="/controllers/stats/<?=$pyr?>/<?=$pm?>"><i class="fa fa-arrow-left"></i> Previous Month</a></li>
+            <a class="btn btn-primary text-nowrap" href="/controllers/stats/<?=$pyr?>/<?=$pm?>"><i class="fa fa-arrow-left"></i> Previous Month</a></li>
         </div>
         <div class="col-sm-8 text-center">
             <h4>Showing Stats for <?=$mname?> 20<?=$year?></h4>
         </div>
         <div class="col-sm-2 text-end">
-            <a class="btn btn-primary" href="/controllers/stats/<?=$nyr?>/<?=$nm?>">Next Month <i class="fa fa-arrow-right"></i></a>
+            <a class="btn btn-primary text-nowrap" href="/controllers/stats/<?=$nyr?>/<?=$nm?>">Next Month <i class="fa fa-arrow-right"></i></a>
         </div>
     </div>
     <br>

--- a/resources/views/layouts/dashboard.blade.php
+++ b/resources/views/layouts/dashboard.blade.php
@@ -17,10 +17,9 @@
         <link rel="stylesheet" href="{{ mix('/css/footer_white.css') }}">
 
         {{-- Bootstrap --}}
-        <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.1/css/bootstrap.min.css" integrity="sha384-WskhaSGFgHYWDcbwN70/dfYBj47jz9qbsMId/iRN3ewGhXQFZCSftd1LZCfmhktB" crossorigin="anonymous">
-        <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js" integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49" crossorigin="anonymous"></script>
-        <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.1/js/bootstrap.min.js" integrity="sha384-smHYKdLADwkXOn1EmN1qk/HfnUcbVRZyYmZ4qpPea6sjB/pTJ0euyQp0Mk8ck+5T" crossorigin="anonymous"></script>
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/css/bootstrap.min.css" integrity="sha384-xOolHFLEh07PJGoPkLv1IbcEPTNtaed2xpHsD9ESMhqIYd0nLMwNLD69Npy4HI+N" crossorigin="anonymous">
+        <script src="https://cdn.jsdelivr.net/npm/jquery@3.5.1/dist/jquery.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-Fy6S3B9q64WdZWQUiU+q4/2Lc9npb8tCaSX9FK7E8HnRr0Jz8D6OP9dO5Vg3Q9ct" crossorigin="anonymous"></script>
 
         {{-- Custom JS --}}
         <script type="text/javascript" src="{{ mix('/js/app.js') }}"></script>

--- a/resources/views/layouts/master.blade.php
+++ b/resources/views/layouts/master.blade.php
@@ -20,10 +20,9 @@
         @endif
 
         {{-- Bootstrap --}}
-        <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.1/css/bootstrap.min.css" integrity="sha384-WskhaSGFgHYWDcbwN70/dfYBj47jz9qbsMId/iRN3ewGhXQFZCSftd1LZCfmhktB" crossorigin="anonymous">
-        <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js" integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49" crossorigin="anonymous"></script>
-        <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.1/js/bootstrap.min.js" integrity="sha384-smHYKdLADwkXOn1EmN1qk/HfnUcbVRZyYmZ4qpPea6sjB/pTJ0euyQp0Mk8ck+5T" crossorigin="anonymous"></script>
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/css/bootstrap.min.css" integrity="sha384-xOolHFLEh07PJGoPkLv1IbcEPTNtaed2xpHsD9ESMhqIYd0nLMwNLD69Npy4HI+N" crossorigin="anonymous">
+        <script src="https://cdn.jsdelivr.net/npm/jquery@3.5.1/dist/jquery.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-Fy6S3B9q64WdZWQUiU+q4/2Lc9npb8tCaSX9FK7E8HnRr0Jz8D6OP9dO5Vg3Q9ct" crossorigin="anonymous"></script>
 
         {{-- Custom JS --}}
         <script type="text/javascript" src="{{ mix('/js/app.js') }}"></script>


### PR DESCRIPTION
This PR will:
* Updates bootstrap on both the landing page and dashboard from v4.1.0 (2018) to v4.6.2 (2022)
* Interim step on the path to v5
* Resolves long list of vulnerabilities
* No breaking changes noted. Changelog here: https://github.com/twbs/bootstrap/releases?page=5
* Minor UI changes required - had to disable text wrapping in some buttons
