### PR TITLE
NOISS: Hides Laratrust panel link

### DIFF
--- a/resources/views/inc/sidebar.blade.php
+++ b/resources/views/inc/sidebar.blade.php
@@ -93,7 +93,9 @@
                 @endif
                 @if(Auth::user()->hasRole('wm') || Auth::user()->hasRole('awm'))
                     <a class="nav-link {{ Nav::urlDoesContain('dashboard/admin/toggles') }}" href="/dashboard/admin/toggles">Feature Toggles</a>
-                    <a class="nav-link {{ Nav::urlDoesContain('laratrust') }}" href="/laratrust">Laratrust Panel</a>
+                    @if(App::environment('local'))
+                        <a class="nav-link {{ Nav::urlDoesContain('laratrust') }}" href="/laratrust">Laratrust Panel</a>
+                    @endif
                 @endif
                 @if(Auth::user()->isAbleTo('events'))
                     <a class="nav-link {{ Nav::urlDoesContain('dashboard/admin/events/denylist') }}" href="/dashboard/admin/events/denylist">Event Denylist</a>


### PR DESCRIPTION
This PR will:
* Hides the Laratrust panel link in the sidebar menu when running in other than 'local' environments
* Panel isn't active in QA/STAG/PROD, so no need for this link to be visible... this is a dev-only feature
