### PR TITLE
#776 Prevent new training ticket drafts from open tab of deleted ticket

### DIFF
--- a/app/Http/Controllers/TrainingDash.php
+++ b/app/Http/Controllers/TrainingDash.php
@@ -830,6 +830,10 @@ class TrainingDash extends Controller {
         $ticket = TrainingTicket::find($id);
 
         if (! $ticket) {
+            if ($request->automated && !$request->is_new) {
+                return response(null);
+            }
+
             $ticket = new TrainingTicket;
         }
 

--- a/resources/assets/js/mix/trainingticket.js
+++ b/resources/assets/js/mix/trainingticket.js
@@ -18,7 +18,8 @@ if (newForm.length || (editForm.length && draft.length)) {
 
     formData.push(
       { name: "action", value: "draft" },
-      { name: "automated", value: true }
+      { name: "automated", value: 1 },
+      { name: "is_new", value: newForm.length }
     );
 
     $.ajax({
@@ -29,6 +30,11 @@ if (newForm.length || (editForm.length && draft.length)) {
         if (newForm.length) {
           window.location.replace(result);
         }
+
+        if (!result) {
+          window.close();
+        }
+
         // Using device time opposed to database
         $("#autosaveIndicator").text(
           "Last autosaved at: " + new Date().toLocaleTimeString()


### PR DESCRIPTION
This PR will:
* Prevent new training ticket drafts from being created due to a tab open of a deleted ticket
* Close #776
