### PR TITLE
NOISS: Corrects text error on profile page

### DIFF
--- a/resources/views/dashboard/controllers/profile.blade.php
+++ b/resources/views/dashboard/controllers/profile.blade.php
@@ -200,7 +200,7 @@ Profile
                         @if(Auth::user()->discord)
                             <div class="col-4">
                                 <a href="/dashboard/controllers/profile/discord" class="btn btn-success text-nowrap" type="button">Update Discord Roles</a>
-                            </div>profile.
+                            </div>
                         @else
                             <div class="col-4">
                                 <a href="#" data-bs-toggle="tooltip" title="No Discord ID Found: Ensure your Discord ID is linked to your VATUSA account. The roster may take time to refresh. You can manually update your role in the ZTL Discord server in the meantime." class="btn btn-secondary" type="button">Update Discord Role</a>


### PR DESCRIPTION
This PR will:
* Removes errant "profile." from discord role button on profile page (bad cut & paste?)
