### PR TITLE
#797 Allow Removing Roster Certifications

### DIFF
--- a/app/Http/Controllers/AdminDash.php
+++ b/app/Http/Controllers/AdminDash.php
@@ -398,7 +398,7 @@ class AdminDash extends Controller {
         if (Auth::user()->isAbleTo('roster') || Auth::user()->isAbleTo('train')) { // Update training certifications
             $positions = ['gnd','clt_del','clt_gnd','clt_twr','clt_app','atl_del','atl_gnd','atl_twr','atl_app','twr_solo_fields'];
             foreach ($positions as $position) {
-                $user[$position] = ($request->input($position)) ? $request->input($position) : $user[$position];
+                $user[$position] = $request->input($position);
             }
             $positions = array_keys(User::$SoloFacilities);
             foreach ($positions as $solo_id => $position) {
@@ -425,7 +425,7 @@ class AdminDash extends Controller {
                     $solo_facility = User::$SoloFacilities[$position] . '_' . strtoupper($position);
                     (new Client())->request('POST', Config::get('vatusa.base').'/v2/solo'.'?apikey='.Config::get('vatusa.api_key').'&cid='.$id.'&position='.$solo_facility.'&expDate='.$expire, ['http_errors' => false]);
                 } else {
-                    $user[$position] = ($request->input($position)) ? $request->input($position) : $user[$position];
+                    $user[$position] = ($user[$position] != $user->getMagicNumber('SOLO_CERTIFICATION')) ? $request->input($position) : $user[$position];
                 }
             }
             $user->twr_solo_fields = $request->input('twr_solo_fields');


### PR DESCRIPTION
This PR will:
* Fix the issue where training staff are not able to remove training certifications
* Still require solo certifications to be removed by clicking the added button
* Close #797 
