### PR TITLE
#809 Fix support event delete modal id

### DIFF
--- a/resources/assets/js/event_index.js
+++ b/resources/assets/js/event_index.js
@@ -1,7 +1,7 @@
 document
   .getElementById("denylistEvent")
   .addEventListener("show.bs.modal", function (e) {
-    const eventId = e.relatedTarget.dataset.id;
+    const eventId = e.relatedTarget.dataset.bsId;
     const deleteLink = this.querySelector("#deleteLink");
     const denylistLink = this.querySelector("#denylistLink");
 


### PR DESCRIPTION
This PR will:
* Fix the modal ID being passed for deleting support events
  * The issue was that the attribute `id` was being accessed, but the actual name is `bsId`
* Close #809
