### PR TITLE
NOISS Check for auth in composer before checking impersonation

### DIFF
--- a/app/View/Composers/ImpersonationComposer.php
+++ b/app/View/Composers/ImpersonationComposer.php
@@ -20,7 +20,7 @@ class ImpersonationComposer {
      * Bind data to the view.
      */
     public function compose(View $view): void {
-        if (toggleEnabled(FeatureToggles::IMPERSONATION)) {
+        if (toggleEnabled(FeatureToggles::IMPERSONATION) && Auth::check()) {
             $users = null;
             $is_impersonating = session()->has(SessionVariables::IMPERSONATE->value);
 


### PR DESCRIPTION
This PR will:
* Fix an issue where non-logged in users are unable to access the website when impersonation is enabled
* Allow enabling impersonation on prod (LEAVE DISABLED UNTIL THIS IS MERGED AND DEPLOYED)