### PR TITLE
NOISS: Add local day tz offset indicator

### DIFF
--- a/app/Event.php
+++ b/app/Event.php
@@ -7,6 +7,7 @@ use GuzzleHttp\Exception\RequestException;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Storage;
 
@@ -116,5 +117,30 @@ class Event extends Model {
         $this->save();
 
         Audit::newAudit('toggled event assignment visibility for ' . $this->name);
+    }
+
+    public function getStartDateTimeAttribute(): Carbon {
+        return Carbon::createFromFormat('m/d/Y H:i', $this->date . ' ' . $this->start_time, 'UTC');
+    }
+
+    public function tzOffsetDayIndicator(): string {
+        $tz_offset_day_indicator = '';
+        $event_utc_start_of_day = $this->start_date_time->clone()->startOfDay();
+        $event_local_start_of_day = $this->start_date_time->clone()->setTimezone(Auth::user()->timezone)->startOfDay();
+        // Change local TZ back to UTC to force diff to compare full days
+        $event_local_start_of_day = $event_local_start_of_day->shiftTimezone('UTC');
+        $utc_local_diff_days = round($event_utc_start_of_day->diffInDays($event_local_start_of_day), 0);
+        //dd($utc_local_diff_days);
+        if ($utc_local_diff_days > 0) {
+            $tz_offset_day_indicator = '(+1)';
+        }
+        if ($utc_local_diff_days < 0) {
+            $tz_offset_day_indicator = '(-1)';
+        }
+        return $tz_offset_day_indicator;
+    }
+
+    public function getLocalTimezoneAbbreviationAttribute(): string {
+        return Carbon::now()->setTimezone(Auth::user()->timezone)->format('T');
     }
 }

--- a/resources/views/dashboard/controllers/events/index.blade.php
+++ b/resources/views/dashboard/controllers/events/index.blade.php
@@ -54,9 +54,9 @@ Events
                         <td>{{ $e->date }}</td>
                         <td>
                             {{ $e->start_time }} to {{ $e->end_time }} Zulu
-                            ({{ timeToLocal($e->start_time, Auth::user()->timezone) }} to {{ timeToLocal($e->end_time, Auth::user()->timezone) }} <a style="color:inherit" href="#" data-bs-toggle="tooltip"
-                                                                                                                                                     title="Showing times in {{ Auth::user()->timezone }}. You can change this on your profile."><i
-                                        class="fas fa-info-circle"></i></a>)
+                            <br>
+                            {{ timeToLocal($e->start_time, Auth::user()->timezone) }} {{ $e->tzOffsetDayIndicator() }} to {{ timeToLocal($e->end_time, Auth::user()->timezone) }} {{ $e->local_timezone_abbreviation }} 
+                            <a style="color:inherit" href="#" data-bs-toggle="tooltip" title="Showing times in {{ Auth::user()->timezone }}. You can change this on your profile."><i class="fas fa-info-circle"></i></a>
                         </td>
                         @if(Auth::user()->isAbleTo('events'))
                             <td>

--- a/resources/views/dashboard/controllers/events/view.blade.php
+++ b/resources/views/dashboard/controllers/events/view.blade.php
@@ -34,10 +34,8 @@ View Event
                     <h5><b>Date:</b> {{ $event->date }}</h5>
                     <h5><b>Time:</b>
                             {{ $event->start_time }} to {{ $event->end_time }} Zulu
-                            ({{ $local_start_time }} to {{ $local_end_time }} local <a style="color:inherit" href="#"
-                                                                                 data-bs-toggle="tooltip"
-                                                                                 title="Showing times in {{ $timezone }}. You can change this on your profile."><i
-                                        class="fas fa-info-circle"></i></a>)
+                            | {{ timeToLocal($event->start_time, Auth::user()->timezone) }} {{ $event->tzOffsetDayIndicator() }} to {{ timeToLocal($event->end_time, Auth::user()->timezone) }} {{ $event->local_timezone_abbreviation }} 
+                        <a style="color:inherit" href="#" data-bs-toggle="tooltip" title="Showing times in {{ $timezone }}. You can change this on your profile."><i class="fas fa-info-circle"></i></a>
                         </h5>
                         <h5><b>Type:</b>
                             @if(Auth::user()->isAbleTo('events'))


### PR DESCRIPTION
This PR will:
* Fulfills a user request to show a local day offset indicator (+1) in the events index and event view which indicates when an event start time occurs in a different local day than the advertised UTC day.
* To test, update your profile timezone to Asia/Tokyo and then view a ZTL event which starts at 23:00 UTC. You will see the following indication:
<img width="382" height="228" alt="image" src="https://github.com/user-attachments/assets/78aa7339-8c0a-4200-bc91-b5ed2e55dd96" />
<img width="638" height="120" alt="image" src="https://github.com/user-attachments/assets/163c5bf7-6506-4dc4-ad86-4117b463a689" />

