### PR TITLE
#940 Limits event unregister

### DIFF
--- a/app/Http/Controllers/ControllerDash.php
+++ b/app/Http/Controllers/ControllerDash.php
@@ -329,7 +329,7 @@ class ControllerDash extends Controller {
     }
 
     public function showEvents() {
-        $discord_event = null;
+        $discord_role = null;
         if (Auth::user()->isAbleTo('events')||Auth::user()->hasRole('events-team')) {
             $events = Event::all()->sortByDesc('date_stamp')->paginate(10);
             $discord_role = Event::whereNotNull('discord_role')->first();
@@ -428,6 +428,12 @@ class ControllerDash extends Controller {
         if (Auth::user()->id != $request->controller_id && !Auth::user()->hasPermission('events')) {
             Audit::newAudit(' attempted to remove an event registration belonging to someone else.');
             return redirect()->back()->with(SessionVariables::ERROR->value, 'Unable to unregister other users - this attempt has been logged.');
+        }
+
+        $event = Event::find($request->event_id);
+        $event_start = Carbon::createFromFormat('m/d/Y H:i', $event->date . ' ' . $event->start_time, 'UTC');
+        if ($event_start->diffInHours(now()) <= 24  && !Auth::user()->hasPermission('events')) {
+            return redirect()->back()->with(SessionVariables::ERROR->value, 'Unable to unregister within 24 hours of event start - please contact the EC.');
         }
 
         $request->delete();


### PR DESCRIPTION
This PR will:
* Prevents controllers from unregistering for an event when request is within 24 hours of the event start time
* Close #940 
