### PR TITLE
#903 Selectable solo cert duration

### DIFF
--- a/app/Console/Commands/RosterUpdate.php
+++ b/app/Console/Commands/RosterUpdate.php
@@ -7,7 +7,6 @@ use App\User;
 use Config;
 use GuzzleHttp\Client;
 use Illuminate\Console\Command;
-use Illuminate\Support\Facades\DB;
 
 class RosterUpdate extends Command {
     /**
@@ -121,8 +120,6 @@ class RosterUpdate extends Command {
             $u->train_pwr = null;
             $u->monitor_pwr = null;
             $u->save();
-
-            DB::table('sessions')->where('user_id', $u->id)->delete();
         }
     }
 }

--- a/app/Console/Commands/RosterUpdate.php
+++ b/app/Console/Commands/RosterUpdate.php
@@ -7,6 +7,7 @@ use App\User;
 use Config;
 use GuzzleHttp\Client;
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
 
 class RosterUpdate extends Command {
     /**
@@ -120,6 +121,8 @@ class RosterUpdate extends Command {
             $u->train_pwr = null;
             $u->monitor_pwr = null;
             $u->save();
+
+            DB::table('sessions')->where('user_id', $u->id)->delete();
         }
     }
 }

--- a/app/Http/Controllers/AdminDash.php
+++ b/app/Http/Controllers/AdminDash.php
@@ -404,12 +404,14 @@ class AdminDash extends Controller {
                     }
                 } elseif ($request->input($position) == $user->getMagicNumber('SOLO_CERTIFICATION')) {
                     $user[$position] = $request->input($position);
-                    $expire = Carbon::now()->addDays($user->getMagicNumber('SOLO_CERT_DURATION'))->format('Y-m-d');
+                    $solo_duration = ($request->input('solo_duration') != '0') ? intval($request->input('solo_duration')) : $user->getMagicNumber('SOLO_CERT_DURATION');
+                    $expire = Carbon::now()->addDays($solo_duration)->format('Y-m-d');
                     $cert = new SoloCert;
                     $cert->cid = $id;
                     $cert->pos = $solo_id;
                     $cert->expiration = $expire;
                     $cert->status = 0;
+                    $cert->duration = $solo_duration;
                     $cert->save();
                     $solo_facility = User::$SoloFacilities[$position] . '_' . strtoupper($position);
                     (new Client())->request('POST', Config::get('vatusa.base').'/v2/solo'.'?apikey='.Config::get('vatusa.api_key').'&cid='.$id.'&position='.$solo_facility.'&expDate='.$expire, ['http_errors' => false]);

--- a/app/Http/Controllers/AdminDash.php
+++ b/app/Http/Controllers/AdminDash.php
@@ -45,6 +45,7 @@ use GuzzleHttp\Exception\RequestException;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Storage;
 use Mail;
@@ -616,6 +617,8 @@ class AdminDash extends Controller {
             if (filter_var($user->email, FILTER_VALIDATE_EMAIL)) {
                 Mail::to($user->email)->send(new VisitorMail('remove', $user));
             }
+
+            DB::table('sessions')->where('user_id', $user->id)->delete();
 
             $client = new Client();
             $req_params = [ 'form_params' =>

--- a/app/Http/Controllers/AdminDash.php
+++ b/app/Http/Controllers/AdminDash.php
@@ -45,7 +45,6 @@ use GuzzleHttp\Exception\RequestException;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Storage;
 use Mail;
@@ -617,8 +616,6 @@ class AdminDash extends Controller {
             if (filter_var($user->email, FILTER_VALIDATE_EMAIL)) {
                 Mail::to($user->email)->send(new VisitorMail('remove', $user));
             }
-
-            DB::table('sessions')->where('user_id', $user->id)->delete();
 
             $client = new Client();
             $req_params = [ 'form_params' =>

--- a/database/migrations/2026_08_06_030253_add_solo_duration.php
+++ b/database/migrations/2026_08_06_030253_add_solo_duration.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void {
+        Schema::table('solo_certs', function (Blueprint $table) {
+            $table->tinyInteger('duration')->default(30);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void {
+        Schema::table('solo_certs', function (Blueprint $table) {
+            $table->dropColumn('duration');
+        });
+    }
+};

--- a/resources/views/dashboard/admin/roster/edit.blade.php
+++ b/resources/views/dashboard/admin/roster/edit.blade.php
@@ -222,7 +222,7 @@ Update Controller
                     </div>
                     @if($user->solo_exp == '' || str_contains($user->solo_exp, 'Expired!'))
                     <div class="col-sm-6">
-                        <label for="solo_duration" class="form-label-date">Solo Certification Duration</label>
+                        <label for="solo_duration" class="form-label-date">Solo Certification Duration (days)</label>
                         {{ html()->select('solo_duration', [0 => '', 15 => '15', 30 => '30', 45=> '45'], 0)->class(['form-select'])->attributes([$solo_disable]) }}
                     </div>
                     @else

--- a/resources/views/dashboard/admin/roster/edit.blade.php
+++ b/resources/views/dashboard/admin/roster/edit.blade.php
@@ -220,10 +220,17 @@ Update Controller
                         <label for="twr_solo_fields">Unrestricted Solo Certifications (list facility IDs)</label>
                         {{ html()->text('twr_solo_fields', $user->twr_solo_fields)->class(['form-control'])->attributes(['maxlength' => 255, $solo_disable]) }}
                     </div>
+                    @if($user->solo_exp == '' || str_contains($user->solo_exp, 'Expired!'))
+                    <div class="col-sm-6">
+                        <label for="solo_duration" class="form-label-date">Solo Certification Duration</label>
+                        {{ html()->select('solo_duration', [0 => '', 15 => '15', 30 => '30', 45=> '45'], 0)->class(['form-select'])->attributes([$solo_disable]) }}
+                    </div>
+                    @else
                     <div class="col-sm-6">
                         <label for="twr_solo_expires" class="form-label-date">Solo Expiration Date</label>
                         {{ html()->text('solo_expires', $user->solo_exp)->class(['form-control'])->attributes(['disabled']) }}
                     </div>
+                    @endif
                 </div>
                 @if(Auth::user()->isAbleTo('roster'))
                 <div class="row mt-2">


### PR DESCRIPTION
This PR will:
* Adds a select input to the roster edit view that allows training staff the ability to select a 15|30|45 day solo cert. Defaults to 30 if no selection is made. Selection results in a variable solo expiration date which is pushed to VATUSA.
* Close #903 
