### PR TITLE
NOISS: Fix event unregister time diff bug

### DIFF
--- a/app/Http/Controllers/ControllerDash.php
+++ b/app/Http/Controllers/ControllerDash.php
@@ -432,7 +432,7 @@ class ControllerDash extends Controller {
 
         $event = Event::find($request->event_id);
         $event_start = Carbon::createFromFormat('m/d/Y H:i', $event->date . ' ' . $event->start_time, 'UTC');
-        if ($event_start->diffInHours(now()) <= 24  && !Auth::user()->hasPermission('events')) {
+        if (now()->diffInHours($event_start) <= 24  && !Auth::user()->hasPermission('events')) {
             return redirect()->back()->with(SessionVariables::ERROR->value, 'Unable to unregister within 24 hours of event start - please contact the EC.');
         }
 


### PR DESCRIPTION
This PR will:
* Fix a bug that was causing the time diff to fail
* This PR reverses the order of inputs resulting in a proper calculation
